### PR TITLE
Added link to "moved to offtopic group" message

### DIFF
--- a/rules_bot.py
+++ b/rules_bot.py
@@ -132,8 +132,9 @@ def off_on_topic(bot, update, groups):
                 name = reply.from_user.first_name
 
             replied_message_text = reply.text
+            replied_message_id = reply.message_id
 
-            text = (f'{name} _wrote:_\n'
+            text = (f'{name} [wrote](t.me/pythontelegrambotgroup/{replied_message_id}):\n'
                     f'{replied_message_text}\n\n'
                     f'⬇️ ᴘʟᴇᴀsᴇ ᴄᴏɴᴛɪɴᴜᴇ ʜᴇʀᴇ ⬇️')
 


### PR DESCRIPTION
If a conversation is moved to the offtopic chat, it's hard for others to find the exact context of the moved conversation, if they didn't read the main conversation. To save time searching for the original message, I suggest to add a link to it in the moved message, so you can look it up easily.

Example for a moved message without context: https://t.me/pythontelegrambottalk/50805