### PR TITLE
Improve taghints, github handler & add inline github issue search

### DIFF
--- a/components/inlinequeries.py
+++ b/components/inlinequeries.py
@@ -65,11 +65,36 @@ def fuzzy_replacements_markdown(query, threshold=95, official_api_links=True):
 
 
 def inline_github(query):
+    """
+    Parse query for issues, PRs and commits SHA
+    Returns a list of `articles`.
+
+    Examples:
+        `#10` - [(title=Tenth Issue title, description=#10)]
+        `#10 #9` - [(title=Ninth Issue title, description=#10 #9)]
+        `@d6d0dec6e0e8b647d140dfb74db66ecb1d00a61d` - [(title=Commit @d6d0dec title, description=@d6d0dec)]
+        `#search` - [(title=An issue with search in it's issue, description=#3),
+                     (title=Another issue with search in it's issue, description=#2),
+                     ... (3 more)]
+        `#10 #search` - [(title=An issue with search in it's issue, description=#10 #3),
+                     (title=Another issue with search in it's issue, description=#10 #2),
+                     ... (3 more)]
+        `#search #10` - [(title=Tenth Issue title, description=#10)]
+            (this means that you can only search if it's the last # in the query.
+            this is because we would be unable to handle two searches at once)
+    """
     # Issues/PRs/Commits
     things = OrderedDict()
     search_query = None
     results = []
 
+    # Search for Issues, PRs and commits in the query and add them to things
+    # For the last found # in the query, if it looks like a search `#search` or
+    # `owner/repo#search` then put it in search_query.
+    # Note that we only allow the last item to be a search query,
+    # as we'd have no way to handle two searches at once `#search1 #search2`.
+    # and it's impossible for the user to select the desired result of search1
+    # without submitting the InlineQuery (thereby sending the message)
     for match in GITHUB_PATTERN.finditer(query):
         owner, repo, number, sha, search_query, full = [match.groupdict()[x] for x in ('owner', 'repo', 'number',
                                                                                        'sha', 'query', 'full')]
@@ -82,19 +107,31 @@ def inline_github(query):
             commit = github_issues.get_commit(sha, owner, repo)
             things[full] = commit
 
-    # If the last thing from the for loop above was a search
+    # If we're not doing a search and we didn't find any things either
+    if not search_query and not things:
+        # We didn't find anything
+        return []
+
+    # If we're searching (last iteration of the loop had a search_query)
     if search_query:
+        # Output 5 search results to the user, so they can decide
         choices = []
         # Output a separate choice for each search result
         for search_result in github_issues.search(search_query):
+            # The choice also needs to contain any Issues/PR/commits that
+            # the user specified by ID, before the search query
             tmp = things.copy()
-            tmp['#' + search_query] = search_result[0]
+            # Then add our search_result
+            tmp['#' + search_query] = search_result
             choices.append(tmp)
     else:
+        # Only a single choice, since we just wanna send a single result to the user
         choices = [things]
 
     # Loop over all the choices we should send to the client
     # Each choice (things) is a dict of things (issues/PRs/commits) to show in that choice
+    # If not searching there will only be a single choice
+    # If searching we have 5 different possibilities we wanna send
     for things in choices:
         # For the title we wanna add the title of the last 'thing'
         title = things[next(reversed(things))].title
@@ -108,12 +145,15 @@ def inline_github(query):
         # Description is the short formats combined with ', '
         description = ', '.join(github_issues.pretty_format(thing, short=True) for thing in things.values())
 
+        # The text that will be sent when user clicks the choice/result
         text = ''
-
-        # Check if there's other stuff than issues/PRs etc. in the query
+        # Check if there's other stuff than issues/PRs etc. in the query by
+        # removing issues/PRs etc. and seeing if there's anything left
         if re.sub(r'|'.join(re.escape(thing) for thing in things.keys()), '', query).strip():
             # Replace every 'thing' with a link to said thing *all at once*
-            # Needs to all at once because otherwise 'blah/blah#2 #2' would break
+            # Needs to all at once because otherwise 'blah/blah#2 #2' would break would turn into something like
+            # [blah/blah[#2](LinkFor#2)](LinkForblah/blah[#2](LinkFor#2))
+            # which isn't even valid markdown
             text = re.sub(r'|'.join(re.escape(thing) for thing in things.keys()),
                           lambda x: f'[{github_issues.pretty_format(things[x.group(0)], short=True)}]'
                                     f'({things[x.group(0)].url})', query)
@@ -139,7 +179,7 @@ def inline_query(bot, update, threshold=20):
                                          key=key,
                                          reply_markup=hint.reply_markup) for key, hint in hints.items()])
 
-        if '#' in query:
+        if '#' in query or '@' in query:
             results_list.extend(inline_github(query))
 
         if ENCLOSING_REPLACEMENT_CHARACTER in query:
@@ -204,7 +244,7 @@ def inline_query(bot, update, threshold=20):
             ))
 
     bot.answer_inline_query(update.inline_query.id, results=results_list, switch_pm_text='Help',
-                            switch_pm_parameter='inline-help')
+                            switch_pm_parameter='inline-help', cache_time=0)
 
 
 def register(dispatcher):

--- a/components/inlinequeries.py
+++ b/components/inlinequeries.py
@@ -76,69 +76,66 @@ def inline_query(bot, update, threshold=20):
                                          key=key,
                                          reply_markup=hint.reply_markup) for key, hint in hints.items()])
 
-        modified, replaced = fuzzy_replacements_markdown(query, official_api_links=True)
-        if modified:
-            results_list.append(article(
-                title="Replace links and show official Bot API documentation",
-                description=', '.join(modified),
-                message_text=replaced))
-
-        modified, replaced = fuzzy_replacements_markdown(query, official_api_links=False)
-        if modified:
-            results_list.append(article(
-                title="Replace links",
-                description=', '.join(modified),
-                message_text=replaced))
-
-        wiki_pages = search.wiki(query, amount=4, threshold=threshold)
-        doc = search.docs(query, threshold=threshold)
-
-        if doc:
-            text = f'*{doc.short_name}*\n' \
-                   f'_python-telegram-bot_ documentation for this {doc.type}:\n' \
-                   f'[{doc.full_name}]({doc.url})'
-            if doc.tg_name:
-                text += f'\n\nThe official documentation has more info about [{doc.tg_name}]({doc.tg_url}).'
-
-            results_list.append(article(
-                title=f'{doc.full_name}',
-                description="python-telegram-bot documentation",
-                message_text=text,
-            ))
-
-        if wiki_pages:
-            # Limit number of search results to maximum
-            wiki_pages = wiki_pages[:49 - len(results_list)]
-            for wiki_page in wiki_pages:
+        if ENCLOSING_REPLACEMENT_CHARACTER in query:
+            modified, replaced = fuzzy_replacements_markdown(query, official_api_links=True)
+            if modified:
                 results_list.append(article(
-                    title=f'{wiki_page[0]}',
-                    description="Github wiki for python-telegram-bot",
-                    message_text=f'Wiki of _python-telegram-bot_\n'
-                                 f'[{wiki_page[0]}]({wiki_page[1]})'
+                    title="Replace links and show official Bot API documentation",
+                    description=', '.join(modified),
+                    message_text=replaced))
+
+            modified, replaced = fuzzy_replacements_markdown(query, official_api_links=False)
+            if modified:
+                results_list.append(article(
+                    title="Replace links",
+                    description=', '.join(modified),
+                    message_text=replaced))
+
+        # If no results so far then search wiki and docs
+        if not results_list:
+            doc = search.docs(query, threshold=threshold)
+            if doc:
+                text = f'*{doc.short_name}*\n' \
+                       f'_python-telegram-bot_ documentation for this {doc.type}:\n' \
+                       f'[{doc.full_name}]({doc.url})'
+                if doc.tg_name:
+                    text += f'\n\nThe official documentation has more info about [{doc.tg_name}]({doc.tg_url}).'
+
+                results_list.append(article(
+                    title=f'{doc.full_name}',
+                    description="python-telegram-bot documentation",
+                    message_text=text,
                 ))
 
-        # "No results" entry
-        if len(results_list) == 0:
+            wiki_pages = search.wiki(query, amount=4, threshold=threshold)
+            if wiki_pages:
+                # Limit number of search results to maximum (-1 cause we might have added a doc above)
+                wiki_pages = wiki_pages[:49]
+                for wiki_page in wiki_pages:
+                    results_list.append(article(
+                        title=f'{wiki_page[0]}',
+                        description="Github wiki for python-telegram-bot",
+                        message_text=f'Wiki of _python-telegram-bot_\n'
+                                     f'[{wiki_page[0]}]({wiki_page[1]})'
+                    ))
+
+        # If no results even after searching wiki and docs
+        if not results_list:
             results_list.append(article(
                 title='❌ No results.',
                 description='',
                 message_text=f'[GitHub wiki]({WIKI_URL}) of _python-telegram-bot_',
             ))
 
-    else:  # no query input
-        # add all wiki pages
-        # TODO: Use slicing to limit items (somehow)
-        count = 0
-        for name, link in search._wiki.items():
-            if count == 50:
-                break
+    else:
+        # If no query then add all wiki pages (max 50)
+        for name, link in search.all_wiki_pages()[:50]:
             results_list.append(article(
                 title=name,
                 description='Wiki of python-telegram-bot',
                 message_text=f'Wiki of _python-telegram-bot_\n'
                              f'[{escape_markdown(name)}]({link})',
             ))
-            count += 1
 
     bot.answer_inline_query(update.inline_query.id, results=results_list, switch_pm_text='Help',
                             switch_pm_parameter='inline-help')

--- a/components/taghints.py
+++ b/components/taghints.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, ParseMode
 from telegram.error import BadRequest
 from telegram.ext import CommandHandler, RegexHandler, run_async
 
@@ -122,16 +122,15 @@ def get_hints(query):
 
 @run_async
 def hint_handler(bot, update):
-    text = update.message.text
     reply_to = update.message.reply_to_message
 
-    msg, reply_markup, _ = get_hint_data(text)
+    hint = get_hints(update.message.text).popitem()[1]
 
-    if msg is not None:
-        update.effective_message.reply_text(msg,
-                                            reply_markup=reply_markup,
+    if hint is not None:
+        update.effective_message.reply_text(hint.msg,
+                                            reply_markup=hint.reply_markup,
                                             reply_to_message_id=reply_to.message_id if reply_to else None,
-                                            parse_mode='Markdown',
+                                            parse_mode=ParseMode.MARKDOWN,
                                             disable_web_page_preview=True)
         try:
             update.effective_message.delete()
@@ -140,6 +139,5 @@ def hint_handler(bot, update):
 
 
 def register(dispatcher):
-    for hashtag in HINTS.keys():
-        dispatcher.add_handler(RegexHandler(r'{}.*'.format(hashtag), hint_handler))
+    dispatcher.add_handler(RegexHandler(rf'{"|".join(HINTS.keys())}.*', hint_handler))
     dispatcher.add_handler(CommandHandler(('hints', 'listhints'), list_available_hints))

--- a/const.py
+++ b/const.py
@@ -34,21 +34,23 @@ OFFTOPIC_RULES = """<b>Topics:</b>
 GITHUB_PATTERN = re.compile(r'''
     (?i)                                # Case insensitivity
     [\s\S]*?                            # Any characters
-    (?:                                 # Optional non-capture group for username/repo
-        (?P<owner>[^\s/\#@]+)            # Matches username/org (any char but whitespace, slash, hashtag and at)
-        (?:/(?P<repo>[^\s/\#@]+))?      # Optionally matches repo, with a slash in front
-    )?                                  # End optional non-capture group
-    (?:                                 # Match either
-        (
-            (?P<number_type>\#|GH-|PR-)     # Hashtag or "GH-" or "PR-"
-            (?:                             # Followed by either
-                (?P<number>\d+)                 # Numbers
-                |                           # Or
-                (?P<query>\S+)                  # A search query (without spaces) (only works inline)
+    (?P<full>                           # Capture for the the whole thing
+        (?:                                 # Optional non-capture group for username/repo
+            (?P<owner>[^\s/\#@]+)            # Matches username/org (any char but whitespace, slash, hashtag and at)
+            (?:/(?P<repo>[^\s/\#@]+))?      # Optionally matches repo, with a slash in front
+        )?                                  # End optional non-capture group
+        (?:                                 # Match either
+            (
+                (?P<number_type>\#|GH-|PR-)     # Hashtag or "GH-" or "PR-"
+                (?:                             # Followed by either
+                    (?P<number>\d+)                 # Numbers
+                    |                           # Or
+                    (?P<query>\S+)                  # A search query (without spaces) (only works inline)
+                )
             )
+        |                                   # Or
+            (?:@?(?P<sha>[0-9a-f]{40}))         # at sign followed by 40 hexadecimal characters
         )
-    |                                   # Or
-        (?:@?(?P<sha>[0-9a-f]{40}))         # at sign followed by 40 hexadecimal characters
     )
 ''', re.VERBOSE)
 

--- a/const.py
+++ b/const.py
@@ -35,16 +35,20 @@ GITHUB_PATTERN = re.compile(r'''
     (?i)                                # Case insensitivity
     [\s\S]*?                            # Any characters
     (?:                                 # Optional non-capture group for username/repo
-        (?P<user>[^\s/\#@]+)            # Matches username (any char but whitespace, slash, hashtag and at)
+        (?P<owner>[^\s/\#@]+)            # Matches username/org (any char but whitespace, slash, hashtag and at)
         (?:/(?P<repo>[^\s/\#@]+))?      # Optionally matches repo, with a slash in front
     )?                                  # End optional non-capture group
     (?:                                 # Match either
         (
-            (?P<number_type>\#|GH-|PR-) # Hashtag or "GH-" or "PR-"
-            (?P<number>\d*)             # followed by numbers
+            (?P<number_type>\#|GH-|PR-)     # Hashtag or "GH-" or "PR-"
+            (?:                             # Followed by either
+                (?P<number>\d+)                 # Numbers
+                |                           # Or
+                (?P<query>\S+)                  # A search query (without spaces) (only works inline)
+            )
         )
     |                                   # Or
-        (?:@?(?P<sha>[0-9a-f]{40}))     # at sign followed by 40 hexadecimal characters
+        (?:@?(?P<sha>[0-9a-f]{40}))         # at sign followed by 40 hexadecimal characters
     )
 ''', re.VERBOSE)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ fuzzywuzzy
 python-Levenshtein
 python-telegram-bot
 Sphinx
+requests

--- a/rules_bot.py
+++ b/rules_bot.py
@@ -251,6 +251,14 @@ def main():
 
     updater.start_polling()
     logger.info('Listening...')
+
+    try:
+        github_issues.set_auth(config['KEYS']['github_client_id'], config['KEYS']['github_client_secret'])
+    except KeyError:
+        logging.info('No github auth set. Rate-limit is 60 requests/hour without auth.')
+
+    github_issues.init_issues(dispatcher.job_queue)
+
     updater.idle()
 
 

--- a/rules_bot.py
+++ b/rules_bot.py
@@ -6,6 +6,7 @@ import time
 from telegram import Bot, ParseMode, MessageEntity, ChatAction
 from telegram.error import BadRequest
 from telegram.ext import CommandHandler, RegexHandler, Updater, MessageHandler, Filters
+from telegram.utils.helpers import escape_markdown
 
 import const
 from components import inlinequeries, taghints
@@ -40,7 +41,8 @@ def inlinequery_help(bot, update):
     text = (f"Use the `{char}`-character in your inline queries and I will replace "
             f"them with a link to the corresponding article from the documentation or wiki.\n\n"
             f"*Example:*\n"
-            f"{SELF_CHAT_ID} I 💙 {char}InlineQueries{char}, but you need an {char}InlineQueryHandler{char} for it.\n\n"
+            f"{escape_markdown(SELF_CHAT_ID)} I 💙 {char}InlineQueries{char}, "
+            f"but you need an {char}InlineQueryHandler{char} for it.\n\n"
             f"*becomes:*\n"
             f"I 💙 [InlineQueries](https://python-telegram-bot.readthedocs.io/en/latest/telegram.html#telegram"
             f".InlineQuery), but you need an [InlineQueryHandler](https://python-telegram-bot.readthedocs.io/en"

--- a/search.py
+++ b/search.py
@@ -138,5 +138,8 @@ class Search:
 
         return best.to_list(amount, threshold)
 
+    def all_wiki_pages(self):
+        return list(self._wiki.items())
+
 
 search = Search()

--- a/util.py
+++ b/util.py
@@ -70,6 +70,12 @@ class GitHubIssues:
         self.etag = None
         self.issues = {}
 
+    def set_auth(self, client_id, client_secret):
+        self.s.params = {
+            'client_id': client_id,
+            'client_secret': client_secret
+        }
+
     def _get_json(self, url, data=None, headers=None):
         # Add base_url if needed
         url = url if url.startswith('https://') or url.startswith('http') else self.base_url + url

--- a/util.py
+++ b/util.py
@@ -183,9 +183,8 @@ class GitHubIssues:
             job_queue.run_once(lambda _, __: self._job(links['next']['url'], job_queue), 5)
         # No more issues
         else:
-            # Add a job that every 10 min checks if the 100 first issues changed, and update them in our cache if needed
-            job_queue.run_repeating(lambda _, __: self._job(links['first']['url'],
-                                                            job_queue, first=True), interval=10 * 60)
+            # In 10 min check if the 100 first issues changed, and update them in our cache if needed
+            job_queue.run_once(lambda _, __: self._job(links['first']['url'], job_queue, first=True), 10 * 60)
 
         # If this is on page one (first) then we wanna save the header
         if first:

--- a/util.py
+++ b/util.py
@@ -1,8 +1,8 @@
-from urllib.error import HTTPError
-from urllib.request import urlopen
+import logging
+from collections import namedtuple
 
 from bs4 import BeautifulSoup
-
+from requests import Session
 from telegram import ParseMode
 
 ARROW_CHARACTER = '➜'
@@ -34,18 +34,9 @@ def reply_or_edit(bot, update, chat_data, text):
                                                                              disable_web_page_preview=True)
 
 
-def get_web_page_title(url):
-    try:
-        soup = BeautifulSoup(urlopen(url), "html.parser")
-        return soup.title.string
-    except HTTPError:
-        return None
-
-
 def get_text_not_in_entities(html):
     soup = BeautifulSoup(html, 'html.parser')
     return ' '.join(soup.find_all(text=True, recursive=False))
-
 
 
 def build_menu(buttons,
@@ -58,3 +49,124 @@ def build_menu(buttons,
     if footer_buttons:
         menu.append(footer_buttons)
     return menu
+
+
+Issue = namedtuple('Issue', 'type, owner, repo, number, url, title, author')
+Commit = namedtuple('Commit', 'owner, repo, sha, url, title, author')
+
+
+class GitHubIssues:
+    def __init__(self, default_owner='python-telegram-bot', default_repo='python-telegram-bot'):
+        self.s = Session()
+        self.s.headers.update({'user-agent': 'bvanrijn/rules-bot'})
+        self.base_url = 'https://api.github.com/'
+        self.default_owner = default_owner
+        self.default_repo = default_repo
+
+        self.logger = logging.getLogger(self.__class__.__qualname__)
+
+        self.etag = None
+        self.issues = {}
+
+    def _get_json(self, url, data=None, headers=None):
+        # Add base_url if needed
+        url = url if url.startswith('https://') or url.startswith('http') else self.base_url + url
+        self.logger.info('Getting %s', url)
+        r = self.s.get(url, params=data, headers=headers)
+        self.logger.debug('status_code=%d', r.status_code)
+        # Only try .json() if we actually got new data
+        return r.ok, None if r.status_code == 304 else r.json(), (r.headers, r.links)
+
+    def pretty_format_issue(self, issue):
+        return (f'{issue.type} '
+                f'{"" if issue.owner == self.default_owner else issue.owner+"/"}'
+                f'{"" if issue.repo == self.default_repo else issue.repo}'
+                f'#{issue.number}: '
+                f'{issue.title} by {issue.author}')
+
+    def pretty_format_commit(self, commit):
+        return (f'Commit '
+                f'{"" if commit.owner == self.default_owner else commit.owner+"/"}'
+                f'{"" if commit.repo == self.default_repo else commit.repo}'
+                f'{commit.sha}: '
+                f'{commit.title} by {commit.author}')
+
+    def get_issue(self,
+                  number: int,
+                  owner=None,
+                  repo=None):
+        # Other owner or repo than default?
+        if owner is not None or repo is not None:
+            owner = owner or self.default_owner
+            repo = repo or self.default_repo
+            ok, data, _ = self._get_json(f'repos/{owner}/{repo}/issues/{number}')
+            # Return issue directly, or unknown if not found
+            return Issue(type=('PR' if 'pull_request' in data else 'Issue') if ok else '',
+                         owner=owner,
+                         repo=repo,
+                         number=number,
+                         url=data['html_url'] if ok else f'https://github.com/{owner}/{repo}/issues/{number}',
+                         title=data['title'] if ok else 'Unknown',
+                         author=data['user']['login'] if ok else 'Unknown')
+
+        # Look the issue up, or if not found, fall back on above code
+        return self.issues.get(number, self.get_issue(number, owner=self.default_owner, repo=self.default_repo))
+
+    def get_commit(self,
+                   sha: int,
+                   owner=None,
+                   repo=None):
+        owner = owner or self.default_owner
+        repo = repo or self.default_repo
+        ok, data, _ = self._get_json(f'repos/{owner}/{repo}/commits/{sha}')
+        return Commit(owner=owner,
+                      repo=repo,
+                      sha=sha,
+                      url=data['html_url'] if ok else f'https://github.com/{owner}/{repo}/commits/{sha}',
+                      title=data['commit']['message'].partition('\n')[0] if ok else 'Unknown',
+                      author=data['commit']['author']['name'] if ok else 'Unknown')
+
+    def _job(self, url, job_queue, first=True):
+        # Load 100 issues
+        # We pass the ETag if we have one (not called from init_issues)
+        ok, data, (modified, headers, links) = self._get_json(url, {
+            'per_page': 100,
+            'state': 'all'
+        }, {'If-None-Match': self.etag} if self.etag else None)
+
+        # If we got status_code 304 not modified
+        if not data:
+            return
+
+        if not ok:
+            print('Something went broke :(')
+            return
+
+        # Add to issue cache
+        for issue in data:
+            self.issues[issue['number']] = Issue(type='PR' if 'pull_request' in issue else 'Issue',
+                                                 owner=self.default_owner,
+                                                 repo=self.default_repo,
+                                                 url=issue['html_url'],
+                                                 number=issue['number'],
+                                                 title=issue['title'],
+                                                 author=issue['user']['login'])
+
+        # If more issues
+        if 'next' in links:
+            # Process next page after 5 sec to not get rate-limited
+            job_queue.run_once(lambda: self._job(links['next']['url'], job_queue), 5)
+        # No more issues
+        else:
+            # Add a job that every 10 min checks if the 100 first issues changed, and update them in our cache if needed
+            job_queue.run_repeating(lambda: self._job(links['first']['url'], job_queue, first=True), interval=10 * 60)
+
+        # If this is on page one (first) then we wanna save the header
+        if first:
+            self.etag = headers['etag']
+
+    def init_issues(self, job_queue):
+        self._job(f'repos/{self.default_owner}/{self.default_repo}/issues', job_queue, first=True)
+
+
+github_issues = GitHubIssues('jsmnbom', 'definitelytyped-firefox-webext-browser')

--- a/util.py
+++ b/util.py
@@ -78,6 +78,7 @@ class GitHubIssues:
         return r.ok, None if r.status_code == 304 else r.json(), (r.headers, r.links)
 
     def pretty_format_issue(self, issue):
+        # PR OwnerIfNotDefault/RepoIfNotDefault#9999: Title by Author
         return (f'{issue.type} '
                 f'{"" if issue.owner == self.default_owner else issue.owner+"/"}'
                 f'{"" if issue.repo == self.default_repo else issue.repo}'
@@ -85,10 +86,11 @@ class GitHubIssues:
                 f'{issue.title} by {issue.author}')
 
     def pretty_format_commit(self, commit):
+        # Commit OwnerIfNotDefault/RepoIfNotDefault@abcdf123456789: Title by Author
         return (f'Commit '
                 f'{"" if commit.owner == self.default_owner else commit.owner+"/"}'
                 f'{"" if commit.repo == self.default_repo else commit.repo}'
-                f'{commit.sha}: '
+                f'@{commit.sha}: '
                 f'{commit.title} by {commit.author}')
 
     def get_issue(self,

--- a/util.py
+++ b/util.py
@@ -86,7 +86,7 @@ class GitHubIssues:
 
     def _get_json(self, url, data=None, headers=None):
         # Add base_url if needed
-        url = url if url.startswith('https://') or url.startswith('http') else self.base_url + url
+        url = url if url.startswith('https://') else self.base_url + url
         self.logger.info('Getting %s', url)
         try:
             r = self.s.get(url, params=data, headers=headers)

--- a/util.py
+++ b/util.py
@@ -7,7 +7,9 @@ from telegram import ParseMode
 
 ARROW_CHARACTER = '➜'
 GITHUB_URL = "https://github.com/"
-DEFAULT_REPO = 'python-telegram-bot/python-telegram-bot'
+DEFAULT_REPO_OWNER = 'python-telegram-bot'
+DEFAULT_REPO_NAME = 'python-telegram-bot'
+DEFAULT_REPO = f'{DEFAULT_REPO_OWNER}/{DEFAULT_REPO_NAME}'
 
 
 def get_reply_id(update):
@@ -56,7 +58,7 @@ Commit = namedtuple('Commit', 'owner, repo, sha, url, title, author')
 
 
 class GitHubIssues:
-    def __init__(self, default_owner='python-telegram-bot', default_repo='python-telegram-bot'):
+    def __init__(self, default_owner=DEFAULT_REPO_OWNER, default_repo=DEFAULT_REPO_NAME):
         self.s = Session()
         self.s.headers.update({'user-agent': 'bvanrijn/rules-bot'})
         self.base_url = 'https://api.github.com/'
@@ -129,6 +131,8 @@ class GitHubIssues:
                       author=data['commit']['author']['name'] if ok else 'Unknown')
 
     def _job(self, url, job_queue, first=True):
+        logging.debug('Getting issues from %s', url)
+
         # Load 100 issues
         # We pass the ETag if we have one (not called from init_issues)
         ok, data, (modified, headers, links) = self._get_json(url, {
@@ -141,7 +145,7 @@ class GitHubIssues:
             return
 
         if not ok:
-            print('Something went broke :(')
+            logging.error('Something went broke :(')
             return
 
         # Add to issue cache
@@ -171,4 +175,4 @@ class GitHubIssues:
         self._job(f'repos/{self.default_owner}/{self.default_repo}/issues', job_queue, first=True)
 
 
-github_issues = GitHubIssues('jsmnbom', 'definitelytyped-firefox-webext-browser')
+github_issues = GitHubIssues()

--- a/util.py
+++ b/util.py
@@ -199,7 +199,9 @@ class GitHubIssues:
                 x = x.title
             return x.strip().lower()
 
-        return process.extract(query, self.issues, scorer=fuzz.partial_ratio, processor=processor, limit=5)
+        # We don't care about the score, so return first element
+        return [result[0] for result in process.extract(query, self.issues, scorer=fuzz.partial_ratio,
+                                                        processor=processor, limit=5)]
 
 
 github_issues = GitHubIssues()


### PR DESCRIPTION
**Taghints**
- Simply type `@roolsbot #` and be presented with a nice list of tag hints + their help
- Start typing, e.g. `@roolsbot #tuto` and it will suggest `#tutorial`

**Github Handler**
- Make github handler much muuuuch faster
- Instead of needing to download the entire webpage for an issue, we now just do a lightweight api request (and if part of `python-telegram-bot/python-telegram-bot`, it is already cached)

**Inline github**
- Github stuff like `#1230`, `bvanrijn/rules-bot#31`, `@9e5b84e2b698aba866f0816e3ee1c8c3320b188a`, `bvanrijn/rules-bot@600af3d3bd0665461d3d24f0b4f605719add0f57` now works in inline mode.
- You can also *search* for issues in `python-telegram-bot/python-telegram-bot` using`@roolsbot #SEARCHQUERY` and it will suggest a couple of issues. (note that `SEARCHQUERY` can't contain whitespace, but since it's doing fuzzy searching, omitting them usually works fine).
- It's possible to combine queries like `#10 #9`, `#10 #search` or even `#search1 bvanrijn/rules-bot#10 #search2`