### PR TITLE
Format square brackets in issue/pr titles correctly

### DIFF
--- a/rules_bot.py
+++ b/rules_bot.py
@@ -209,7 +209,7 @@ def github(update: Update, context: CallbackContext):
             things[commit.url] = github_issues.pretty_format_commit(commit)
 
     if things:
-        reply_or_edit(update, context, '\n'.join([f'[{name}]({url})' for url, name in things.items()]))
+        reply_or_edit(update, context, '\n'.join([f'<a href="{url}">{name}</a>' for url, name in things.items()]))
 
 
 def error(update: Update, context: CallbackContext):

--- a/util.py
+++ b/util.py
@@ -30,18 +30,18 @@ def reply_or_edit(update, context, text):
     chat_data = context.chat_data
     if update.edited_message:
         chat_data[update.edited_message.message_id].edit_text(text,
-                                                              parse_mode=ParseMode.MARKDOWN,
+                                                              parse_mode=ParseMode.HTML,
                                                               disable_web_page_preview=True)
     else:
         issued_reply = get_reply_id(update)
         if issued_reply:
             chat_data[update.message.message_id] = context.bot.sendMessage(update.message.chat_id, text,
                                                                            reply_to_message_id=issued_reply,
-                                                                           parse_mode=ParseMode.MARKDOWN,
+                                                                           parse_mode=ParseMode.HTML,
                                                                            disable_web_page_preview=True)
         else:
             chat_data[update.message.message_id] = update.message.reply_text(text,
-                                                                             parse_mode=ParseMode.MARKDOWN,
+                                                                             parse_mode=ParseMode.HTML,
                                                                              disable_web_page_preview=True)
 
 


### PR DESCRIPTION
Seemingly telegrams markdown can't cope with stuff like `[Inline [url]](https://github.com)`, so I replaced markdown formatting with html.
Should make rules' messages more readable again …