### PR TITLE
Expand inline search

### DIFF
--- a/components/inlinequeries.py
+++ b/components/inlinequeries.py
@@ -234,6 +234,46 @@ def inline_query(update: Update, context: CallbackContext, threshold=15):
                     description=', '.join(modified),
                     message_text=replaced))
 
+        if query.lower() == 'faq':
+            for name, link in search.all_faq()[:50]:
+                results_list.append(article(
+                    title=name,
+                    description='Wiki of python-telegram-bot',
+                    message_text=f'Wiki of <i>python-telegram-bot</i>\n'
+                    f'<a href="{link}">{escape_markdown(name)}</a>',
+                ))
+        if query.lower().startswith('faq') and len(query.split(' ')) > 1:
+            faq = search.faq(query.split(' ', 1)[1], amount=20, threshold=threshold)
+            if faq:
+                faq = faq[:50]
+                for q in faq:
+                    results_list.append(article(
+                        title=f'{q[0]}',
+                        description="Github wiki for python-telegram-bot",
+                        message_text=f'Wiki of <i>python-telegram-bot</i>\n'
+                        f'<a href="{q[1]}">{q[0]}</a>'
+                    ))
+
+        if query.lower() == 'snippets':
+            for name, link in search.all_faq()[:50]:
+                results_list.append(article(
+                    title=name,
+                    description='Wiki of python-telegram-bot',
+                    message_text=f'Wiki of <i>python-telegram-bot</i>\n'
+                    f'<a href="{link}">{escape_markdown(name)}</a>',
+                ))
+        if query.lower().startswith('snippets') and len(query.split(' ')) > 1:
+            snippets = search.code_snippets(query.split(' ', 1)[1], amount=20, threshold=threshold)
+            if snippets:
+                snippets = snippets[:50]
+                for snippet in snippets:
+                    results_list.append(article(
+                        title=f'{snippet[0]}',
+                        description="Github wiki for python-telegram-bot",
+                        message_text=f'Wiki of <i>python-telegram-bot</i>\n'
+                        f'<a href="{snippet[1]}">{snippet[0]}</a>'
+                    ))
+
         # If no results so far then search wiki and docs
         if not results_list:
             doc = search.docs(query, threshold=threshold)

--- a/search.py
+++ b/search.py
@@ -52,6 +52,8 @@ class Search:
         self._docs = {}
         self._official = {}
         self._wiki = OrderedDict()  # also examples
+        self._snippets = OrderedDict()
+        self._faq = OrderedDict()
         self.last_cache_date = date.today()
         self._parse()
 
@@ -95,6 +97,7 @@ class Search:
         for h4 in code_snippet_soup.select('div#wiki-body h4'):
             name = f'Code snippets {ARROW_CHARACTER} {h4.text.strip()}'
             self._wiki[name] = urljoin(WIKI_CODE_SNIPPETS_URL, h4.a['href'])
+            self._snippets[name] = self._wiki[name]
 
     def parse_wiki_faq(self):
         request = Request(WIKI_FAQ_URL, headers={'User-Agent': USER_AGENT})
@@ -102,6 +105,7 @@ class Search:
         for h4 in code_snippet_soup.select('div#wiki-body h3'):
             name = f'FAQ {ARROW_CHARACTER} {h4.text.strip()}'
             self._wiki[name] = urljoin(WIKI_FAQ_URL, h4.a['href'])
+            self._faq[name] = self._wiki[name]
 
     def parse_examples(self):
         self._wiki['Examples'] = EXAMPLES_URL
@@ -165,19 +169,36 @@ class Search:
             return best[1]
 
     @cached_parsing
-    def wiki(self, query, amount=5, threshold=50):
+    def _get_results(self, candidates, query, amount=5, threshold=50):
         best = BestHandler()
         best.add(0, ('HOME', WIKI_URL))
         if query != '':
-            for name, link in self._wiki.items():
+            for name, link in candidates.items():
                 score = fuzz.ratio(query.lower(), name.split(ARROW_CHARACTER)[-1].strip().lower())
                 best.add(score, (name, link))
 
         return best.to_list(amount, threshold)
 
+    def faq(self, query, amount=5, threshold=50):
+        return self._get_results(self._faq, query, amount, threshold)
+
+    def code_snippets(self, query, amount=5, threshold=50):
+        return self._get_results(self._snippets, query, amount, threshold)
+
+    def wiki(self, query, amount=5, threshold=50):
+        return self._get_results(self._wiki, query, amount, threshold)
+
     @cached_parsing
     def all_wiki_pages(self):
         return list(self._wiki.items())
+
+    @cached_parsing
+    def all_code_snippets(self):
+        return list(self._snippets.items())
+
+    @cached_parsing
+    def all_faq(self):
+        return list(self._faq.items())
 
 
 search = Search()

--- a/search.py
+++ b/search.py
@@ -84,12 +84,13 @@ class Search:
         wiki_soup = BeautifulSoup(urlopen(request), "html.parser")
 
         # Parse main pages from custom sidebar
-        for ol in wiki_soup.select("div.wiki-custom-sidebar > ol"):
-            category = ol.find_previous_sibling('h2').text.strip()
-            for li in ol.select('li'):
-                if li.a['href'] != '#':
-                    name = f'{category} {ARROW_CHARACTER} {li.a.text.strip()}'
-                    self._wiki[name] = urljoin(WIKI_URL, li.a['href'])
+        for tag in ['ol', 'ul']:
+            for element in wiki_soup.select(f"div.wiki-custom-sidebar > {tag}"):
+                category = element.find_previous_sibling('h2').text.strip()
+                for li in element.select('li'):
+                    if li.a['href'] != '#':
+                        name = f'{category} {ARROW_CHARACTER} {li.a.text.strip()}'
+                        self._wiki[name] = urljoin(WIKI_URL, li.a['href'])
 
     def parse_wiki_code_snippets(self):
         request = Request(WIKI_CODE_SNIPPETS_URL, headers={'User-Agent': USER_AGENT})


### PR DESCRIPTION
* in inline mode type `faq` or `snippets` to list all FAQ/Code Snippets
* type `faq/snippets <query>` to search in FAQ/Snippets
* make rules also find the transition guides. the problem was that unnumbered lists in the sidebar where not parsed