### PR TITLE
Overhaul

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
           - --rcfile=setup.cfg
         additional_dependencies:
           - beautifulsoup4
-          - fuzzywuzzy
+          - thefuzz==0.19.0
           - python-telegram-bot==13.7
           - Sphinx
           - requests

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ rules-bot tries really hard to provide you with the closest match to your query.
 
 Also, special prefixes restrict the search results:
 
-* Prepending the query with `/` will search *only* for [tag hits](#short-replies)
+* Prepending the query with `/` will search *only* for [tag hints](#short-replies)
 * Prepending the query with `#`/`PR-`/`GH-` will search *only* for entries on GitHub as described [above](#link-to-github-threads). This also allows you to search issues & pull request titles on the [GitHub repository](https://github.com/python-telegram-bot/python-telegram-bot).
 
 ### Insertion Search

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ rules-bot will automatically delete the service messages announcing new members.
 
 * `/docs`: Sends the link to the docs.
 * `/wiki`: Sends the link to the wiki.
-* `/hints` & `/listhints`: Sends a list of available tag hints (see [here](#short---replies))
+* `/hints` & `/listhints`: Sends a list of available tag hints (see [here](#short-replies))
 * `/help`: Links to this readme.
 * `/say_potato`: Asks a user to verify that they are not a userbot. Only available to group admins.
 
@@ -60,7 +60,7 @@ rules-bot tries really hard to provide you with the closest match to your query.
 
 Also, special prefixes restrict the search results:
 
-* Prepending the query with `/` will search *only* for [tag hits](#short---replies)
+* Prepending the query with `/` will search *only* for [tag hits](#short-replies)
 * Prepending the query with `#`/`PR-`/`GH-` will search *only* for entries on GitHub as described [above](#link-to-github-threads). This also allows you to search issues & pull request titles on the [GitHub repository](https://github.com/python-telegram-bot/python-telegram-bot).
 
 ### Insertion Search

--- a/README.md
+++ b/README.md
@@ -4,11 +4,69 @@ The Telegram bot @roolsbot serves the python-telegram-bot [group](https://telegr
 
 So what exactly can this bot do?
 
-## Search docs & wiki
+## Short-Replies
 
-You can use the inline mode to search for entries in the documentation or the wiki. Simply type `@roolsbot <your search keywords>` and select one of the results. To search exclusively within the [code snippets](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Code-snippets) or [FAQ](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Frequently-Asked-Questions), type `@roolsbot snippets/faq <your search keywords>`.
+rules-bot provides a number of predefined messages that are frequently needed. A list of available tag hints is available via the `/hints` command and also in the command menu. Simply send `/<taghint>` and rules-bot will delete your message and send the corresponding text instead. Reply to a message with `/<taghint>` to make rules-bot send the message as reply to that message. Type `/<taghint> <a personal message>`, to insert the personal message at a meaningful spot within the message. For most tag hints this will just prepend the personal message. You can even send multiple short messages at once by typing `/<taghint 1> <message 1> /<taghint 2> <message 2> ...`
 
-To nicely insert those links directly into your message, you can enclose the search keywords by `+`, e.g.
+## Redirect to On- & Off-Topic
+
+To redirect a user to the on-/off-topic group simply reply with `/on_topic` or `/off_topic` to their message. The hint may also be part of a longer message.
+
+### Link to GitHub Threads
+
+## Search GitHub
+
+When mentioning issues, pull requests, commit SHAs or `ptbcontrib` contributions in the same manner, rules-bot will automatically reply to your message with the corresponding links to the [GitHub repository](https://github.com/python-telegram-bot/python-telegram-bot) of python-telegram-bot. If your message is a reply to another message, the links will be sent as reply to that message.
+
+Mentioning those works in the following forms:
+
+* `ptbcontrib/name` with the (directory) name of a contribution of [ptbcontrib](https://github.com/python-telegram-bot/ptbcontrib/tree/main/ptbcontrib)
+* `#number` with the number of an issue/pull request
+* `#phrase` with a phrase to search for in issue/pull request titles
+* `@sha` with a commit SHA
+
+In the last three cases, `#` may be replaced by `GH-` or `PR-` or you can prepend
+
+* `repo` to search in the repo `https://github.com/python-telegram-bot/repo`
+* `owner/` to search in the repo `https://github.com/owner/repo`
+
+### Welcome Members
+
+rules-bot will automatically delete the service messages announcing new members. Instead, it will welcome new members by mentioning them in a short message that links to a message stating the rules of the group. New members are welcomed in batches. Currently, there will be at most one welcoming message per hour. The linked rules messages are updated with the current rules on start-up.
+
+## Fixed Commands
+
+* `/docs`: Sends the link to the docs.
+* `/wiki`: Sends the link to the wiki.
+* `/hints` & `/listhints`: Sends a list of available tag hints (see [here](#short---replies))
+* `/help`: Links to this readme.
+* `/say_potato`: Asks a user to verify that they are not a userbot. Only available to group admins.
+
+## Inline Mode
+
+rules-bot has an extensive inline functionality. It has basically two components:
+
+### Direct Search
+
+Typing `@roolsbot <search query>` will present you with a list of search results, from which you can select. Things than can be searched for:
+
+* [Wiki](https://github.com/python-telegram-bot/python-telegram-bot/wiki) pages
+* entries on the [FAQ](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Frequently-Asked-Questions) and [code snippets](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Code-snippets) pages
+* Entries in the [documentation](https://python-telegram-bot.readthedocs.io/en/stable/)
+* Examples from the [examples directory](https://github.com/python-telegram-bot/python-telegram-bot/tree/master/examples#examples)
+* Tag hints as described [above](#short-replies)
+
+rules-bot tries really hard to provide you with the closest match to your query. This is not always easy, so you might need to scroll a bit.
+
+Also, special prefixes restrict the search results:
+
+* Prepending the query with `/` will search *only* for [tag hits](#short---replies)
+* Prepending the query with `#`/`PR-`/`GH-` will search *only* for entries on GitHub as described [above](#link-to-github-threads). This also allows you to search issues & pull request titles on the [GitHub repository](https://github.com/python-telegram-bot/python-telegram-bot).
+
+### Insertion Search
+
+Instead of searching for just one result, you can also insert links into a message by wrapping search queries in `+<search query>+`. The syntax for the search queries is exactly as described above. For example
+
 ```
 @roolsbot I 💙 +InlineQueries+, but you need an +InlineQueryHandler+ for it.
 ```
@@ -16,58 +74,9 @@ becomes
 
 > I 💙 [InlineQueries](https://python-telegram-bot.readthedocs.io/en/stable/telegram.inlinequery.html#telegram.InlineQuery), but you need an [InlineQueryHandler](https://python-telegram-bot.readthedocs.io/en/stable/telegram.ext.inlinequeryhandler.html#telegram.ext.InlineQueryHandler) for it.
 
-You can also choose to include links to the official Bot API docs, where available.
+For each inserted search query, rules-bot will search for the three best matches and will offer you all possible combinations of the corresponding results.
 
-All search is fuzzy, i.e. a few typos won't matter.
-
-## Search GitHub
-
-The inline mode can also be used to search for threads and commits in the [GitHub repository](https://github.com/python-telegram-bot/python-telegram-bot) of python-telegram-bot. Simply type `@roolsbot <your query>` and select the result. The search query may be of the form
-
-* `ptbcontrib/name` with the (directory) name of a contribution of [ptbcontrib](https://github.com/python-telegram-bot/ptbcontrib/tree/main/ptbcontrib)
-* `#number` with the number of an issue/pull request
-* `#phares` with a phrase to search for in issue/pull request titles
-* `@sha` with a commit SHA
-
-In the list three cases, `#` may be replaced by `GH-` or `PR-` and you can prepend
-
-* `repo` to search in the repo `https://github.com/python-telegram-bot/repo`
-* `owner/` to search in the repo `https://github.com/owner/repo`
-
-Of course, you can also insert those links directly into your message, e.g.
-
-```
-@roolsbot Pull Request #1920 is about #TypeHinting.
-```
-
-## Short-Replies
-
-rules-bot provides a number of predefined messages that are frequently needed. A list of available tag hints is available via the `/hints` command. Simply send `#<taghint>` and rules-bot will delete your message and send the corresponding text instead. Reply to a message with `#<taghint>` to make rules-bot send the message as reply to that message. Type `#<taghint> <a personal message>`, to insert the personal message at a meaningful spot within the message. For most tag hints this will just prepend the personal message. You can even send multiple short messages at once by typing `#<taghint 1> <message 1> #<taghint 2> <message 2> ...`
-
-Tag hints are also available via the inline mode. Typing `@roolsbot #taghint` allows you to send the message yourself instead of having rules-bot send it. Personal messages work just like described above, though inline mode only supports one tag hint at a time.
-
-## Things it does automatically
-
-rules-bot does a number of things without explicitly requesting it. This includes: 
-
-## Redirect to On- & Off-Topic
-
-To redirect a user to the on-/off-topic group simply reply with `on-topic` or `off-topic` to their message. rules-bot accepts different variants of this (e.g. `#off-topic`, `offtopic`, `off topic` are valid) and the hint may also be part of a longer message. 
-
-### Link to GitHub Threads
-
-When mentioning issues, pull requests, commit SHAs or `ptbcontrib` contributions in the same manner as described above in [Search GitHub](#search-github), rules-bot will automatically reply to your message with the corresponding links. If your message is a reply to another message, the links will be sent as reply to that message.
-
-### Welcome members
-
-rules-bot will automatically delete the service messages announcing new members. Instead, it will welcome new members by mentioning them in a short message that links to a message stating the rules of the group. New members are welcomed in batches. Currently, there will be at most one welcoming message per hour. The linked rules messages are updated with the current rules on start-up.
-
-## Fixed commands
-
-* `/docs`: Sends the link to the docs.
-* `/wiki`: Sends the link to the wiki.
-* `/hints` & `/listhints`: Sends a list of available tag hints (see [here](#short---replies))
-* `/help`: Links to this readme.
+Please note that Telegram will only parse the first 256 characters of your inline query. Everything else will be cut off.
 
 ## Other
 

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -220,16 +220,14 @@ def off_on_topic(update: Update, context: CallbackContext) -> None:
 
         else:
             message.reply_text(
-                "The off-topic group is [here](https://telegram.me/pythontelegrambottalk). "
+                f'The off-topic group is <a href="https://t.me/{OFFTOPIC_USERNAME}">here</a>. '
                 "Come join us!",
-                parse_mode=ParseMode.MARKDOWN,
             )
 
     elif chat_username == OFFTOPIC_USERNAME and group_one.lower() == "on":
         message.reply_text(
-            "The on-topic group is [here](https://telegram.me/pythontelegrambotgroup). "
+            f'The on-topic group is <a href="https://t.me/{ONTOPIC_USERNAME}">here</a>. '
             "Come join us!",
-            parse_mode=ParseMode.MARKDOWN,
         )
 
     if parsed_messages.full():
@@ -341,7 +339,7 @@ def do_greeting(
         else OFFTOPIC_RULES_MESSAGE_LINK
     )
     text = (
-        f'Welcome {", ".join(users)}! If you haven\'t already, read the rules of this '
+        f"Welcome {', '.join(users)}! If you haven't already, read the rules of this "
         f'group and be sure to follow them. You can find them <a href="{link}">here 🔗</a>.'
     )
 
@@ -505,6 +503,16 @@ def say_potato_button(update: Update, context: CallbackContext) -> None:
 
 def say_potato_command(update: Update, context: CallbackContext) -> None:
     message = cast(Message, update.effective_message)
+    who_banned = cast(User, message.from_user)
+    chat = cast(Chat, update.effective_chat)
+
+    # This check will fail if we add or remove admins at runtime but that is so rare that
+    # we can just restart the bot in that case ...
+    admins = cast(Dict, context.chat_data).setdefault("admins", chat.get_administrators())
+    if who_banned not in [admin.user for admin in admins]:
+        message.reply_text("This command is only available for admins. You are not an admin.")
+        return
+
     message.delete()
 
     if not message.reply_to_message:
@@ -528,7 +536,7 @@ def say_potato_command(update: Update, context: CallbackContext) -> None:
         f"clicking the button that says <code>{correct}</code>. If you don't press the button "
         f"within {time_limit} minutes, you will be banned from the PTB groups. If you miss the "
         f"time limit but are not a userbot and want to get unbanned, please contact "
-        f"{cast(User, message.from_user).mention_html()}."
+        f"{who_banned.mention_html()}."
     )
 
     answers = random.sample([(correct, True), (incorrect_1, False), (incorrect_2, False)], 3)

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -461,7 +461,7 @@ def tag_hint(update: Update, _: CallbackContext) -> None:
     )
 
     if reply_to:
-        message.delete()
+        try_to_delete(message)
 
 
 def say_potato_job(context: CallbackContext) -> None:

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -2,6 +2,8 @@ import datetime as dtm
 import html
 import logging
 import time
+from queue import Queue
+import random
 from typing import cast, Match, List, Dict, Any, Optional, Tuple
 
 from telegram import (
@@ -14,10 +16,15 @@ from telegram import (
     ChatMemberUpdated,
     ChatMember,
     TelegramError,
+    InlineKeyboardMarkup,
+    InlineKeyboardButton,
+    User,
+    CallbackQuery,
 )
-from telegram.ext import CallbackContext, JobQueue
+from telegram.ext import CallbackContext, JobQueue, Job
 from telegram.utils.helpers import escape_markdown
 
+from components import const
 from components.const import (
     OFFTOPIC_USERNAME,
     ONTOPIC_USERNAME,
@@ -29,8 +36,11 @@ from components.const import (
     ONTOPIC_RULES_MESSAGE_LINK,
     OFFTOPIC_RULES_MESSAGE_LINK,
     NEW_CHAT_MEMBERS_LIMIT_SPACING,
+    VEGETABLES,
+    ONTOPIC_CHAT_ID,
 )
 from components.entrytypes import BaseEntry
+from components.taghints import TAG_HINTS, TAG_HINTS_PATTERN
 from components.util import (
     rate_limit,
     get_reply_id,
@@ -45,9 +55,9 @@ def start(update: Update, context: CallbackContext) -> None:
     username = cast(Chat, update.effective_chat)
     args = context.args
     if args:
-        if args[0] == 'inline-help':
+        if args[0] == "inline-help":
             inlinequery_help(update, context)
-        if args[0] == 'inline-entity-parsing':
+        if args[0] == "inline-entity-parsing":
             inlinequery_entity_parsing(update, context)
     elif username not in (OFFTOPIC_USERNAME, ONTOPIC_USERNAME):
         message.reply_text(
@@ -59,7 +69,7 @@ def start(update: Update, context: CallbackContext) -> None:
 def inlinequery_help(update: Update, context: CallbackContext) -> None:
     chat_id = cast(Message, update.message).chat_id
     char = ENCLOSING_REPLACEMENT_CHARACTER
-    self_chat_id = f'@{context.bot.username}'
+    self_chat_id = f"@{context.bot.username}"
     text = (
         f"Use the `{char}`-character in your inline queries and I will replace "
         f"them with a link to the corresponding article from the documentation or wiki.\n\n"
@@ -118,7 +128,7 @@ def docs(update: Update, _: CallbackContext) -> None:
     reply_id = message.reply_to_message.message_id if message.reply_to_message else None
     message.reply_text(
         text,
-        parse_mode='Markdown',
+        parse_mode="Markdown",
         quote=False,
         reply_to_message_id=reply_id,
     )
@@ -139,7 +149,7 @@ def wiki(update: Update, _: CallbackContext) -> None:
     reply_id = message.reply_to_message.message_id if message.reply_to_message else None
     message.reply_text(
         text,
-        parse_mode='Markdown',
+        parse_mode="Markdown",
         quote=False,
         reply_to_message_id=reply_id,
     )
@@ -151,9 +161,9 @@ def help_callback(update: Update, context: CallbackContext) -> None:
     """ Link to rules readme """
     message = cast(Message, update.effective_message)
     text = (
-        f'You can find an explanation of @{html.escape(context.bot.username)}\'s functionality '
+        f"You can find an explanation of @{html.escape(context.bot.username)}'s functionality "
         'wiki on <a href="https://github.com/python-telegram-bot/rules-bot/blob/master/README.md">'
-        'GitHub</a>.'
+        "GitHub</a>."
     )
     reply_id = message.reply_to_message.message_id if message.reply_to_message else None
     message.reply_text(
@@ -165,37 +175,48 @@ def help_callback(update: Update, context: CallbackContext) -> None:
 
 
 def off_on_topic(update: Update, context: CallbackContext) -> None:
+    # Minimal effort LRU cache
+    parsed_messages = cast(Dict, context.chat_data).setdefault(
+        "redirect_messages", Queue(maxsize=64)
+    )
+
     message = cast(Message, update.effective_message)
+    if message.message_id in parsed_messages:
+        return
+    if parsed_messages.full():
+        parsed_messages.get()
+        parsed_messages.task_done()
+
     chat_username = cast(Chat, update.effective_chat).username
     group_one = cast(Match, context.match).group(1)
-    if chat_username == ONTOPIC_USERNAME and group_one.lower() == 'off':
+    if chat_username == ONTOPIC_USERNAME and group_one.lower() == "off":
         reply = message.reply_to_message
-        moved_notification = 'I moved this discussion to the [off-topic Group]({}).'
+        moved_notification = "I moved this discussion to the [off-topic Group]({})."
         if reply and reply.text:
             issued_reply = get_reply_id(update)
 
             if reply.from_user:
                 if reply.from_user.username:
-                    name = '@' + reply.from_user.username
+                    name = "@" + reply.from_user.username
                 else:
                     name = reply.from_user.first_name
             else:
-                name = 'Somebody'
+                name = "Somebody"
 
             replied_message_text = reply.text_html
             replied_message_id = reply.message_id
 
             text = (
                 f'{name} <a href="t.me/pythontelegrambotgroup/{replied_message_id}">wrote</a>:\n'
-                f'{replied_message_text}\n\n'
-                f'⬇️ ᴘʟᴇᴀsᴇ ᴄᴏɴᴛɪɴᴜᴇ ʜᴇʀᴇ ⬇️'
+                f"{replied_message_text}\n\n"
+                f"⬇️ ᴘʟᴇᴀsᴇ ᴄᴏɴᴛɪɴᴜᴇ ʜᴇʀᴇ ⬇️"
             )
 
             offtopic_msg = context.bot.send_message(OFFTOPIC_CHAT_ID, text)
 
             message.reply_text(
                 moved_notification.format(
-                    'https://telegram.me/pythontelegrambottalk/' + str(offtopic_msg.message_id)
+                    "https://telegram.me/pythontelegrambottalk/" + str(offtopic_msg.message_id)
                 ),
                 parse_mode=ParseMode.MARKDOWN,
                 reply_to_message_id=issued_reply,
@@ -203,24 +224,28 @@ def off_on_topic(update: Update, context: CallbackContext) -> None:
 
         else:
             message.reply_text(
-                'The off-topic group is [here](https://telegram.me/pythontelegrambottalk). '
-                'Come join us!',
+                "The off-topic group is [here](https://telegram.me/pythontelegrambottalk). "
+                "Come join us!",
                 parse_mode=ParseMode.MARKDOWN,
             )
 
-    elif chat_username == OFFTOPIC_USERNAME and group_one.lower() == 'on':
+        parsed_messages.put(message.message_id)
+
+    elif chat_username == OFFTOPIC_USERNAME and group_one.lower() == "on":
         message.reply_text(
-            'The on-topic group is [here](https://telegram.me/pythontelegrambotgroup). '
-            'Come join us!',
+            "The on-topic group is [here](https://telegram.me/pythontelegrambotgroup). "
+            "Come join us!",
             parse_mode=ParseMode.MARKDOWN,
         )
+
+        parsed_messages.put(message.message_id)
 
 
 def sandwich(update: Update, context: CallbackContext) -> None:
     message = cast(Message, update.effective_message)
     username = cast(Chat, update.effective_chat).username
     if username == OFFTOPIC_USERNAME:
-        if 'sudo' in cast(Match, context.match).group(0):
+        if "sudo" in cast(Match, context.match).group(0):
             message.reply_text("Okay.", quote=True)
         else:
             message.reply_text("What? Make it yourself.", quote=True)
@@ -242,7 +267,7 @@ def github(update: Update, context: CallbackContext) -> None:
     for match in GITHUB_PATTERN.finditer(get_text_not_in_entities(message.text_html)):
         logging.debug(match.groupdict())
         owner, repo, number, sha, ptbcontrib = [
-            match.groupdict()[x] for x in ('owner', 'repo', 'number', 'sha', 'ptbcontrib')
+            match.groupdict()[x] for x in ("owner", "repo", "number", "sha", "ptbcontrib")
         ]
         if number or sha or ptbcontrib:
             thing_matches.append((owner, repo, number, sha, ptbcontrib))
@@ -267,7 +292,7 @@ def github(update: Update, context: CallbackContext) -> None:
         reply_or_edit(
             update,
             context,
-            '\n'.join([thing.html_markup for thing in things]),
+            "\n".join([thing.html_markup() for thing in things]),
         )
 
 
@@ -327,10 +352,10 @@ def do_greeting(
     users.clear()
 
     # save new timestamp
-    chat_data['new_chat_members_timeout'] = dtm.datetime.now()
+    chat_data["new_chat_members_timeout"] = dtm.datetime.now()
 
     # Send message
-    bot.send_message(chat_id=f'@{group_user_name}', text=text)
+    bot.send_message(chat_id=f"@{group_user_name}", text=text)
 
 
 def greet_new_chat_members(update: Update, context: CallbackContext) -> None:
@@ -353,7 +378,7 @@ def greet_new_chat_members(update: Update, context: CallbackContext) -> None:
 
     # Get saved users
     chat_data = cast(dict, context.chat_data)
-    user_lists = chat_data.setdefault('new_chat_members', {})
+    user_lists = chat_data.setdefault("new_chat_members", {})
     users = user_lists.setdefault(group_user_name, [])
 
     # save new user
@@ -361,7 +386,7 @@ def greet_new_chat_members(update: Update, context: CallbackContext) -> None:
 
     # check rate limit
     last_message_date = chat_data.setdefault(
-        'new_chat_members_timeout',
+        "new_chat_members_timeout",
         dtm.datetime.now() - dtm.timedelta(minutes=NEW_CHAT_MEMBERS_LIMIT_SPACING + 1),
     )
     next_possible_greeting_time = last_message_date + dtm.timedelta(
@@ -370,9 +395,9 @@ def greet_new_chat_members(update: Update, context: CallbackContext) -> None:
     if dtm.datetime.now() < next_possible_greeting_time:
         # We schedule a job to the next possible greeting time so that people are greeted
         # and presented with the rules as early as possible while not exceeding the rate limit
-        logging.debug('Scheduling job to greet new members after greetings-cool down.')
+        logging.debug("Scheduling job to greet new members after greetings-cool down.")
         job_queue = cast(JobQueue, context.job_queue)
-        jobs = job_queue.get_jobs_by_name('greetings_job')
+        jobs = job_queue.get_jobs_by_name("greetings_job")
         if not jobs:
             job_queue.run_once(
                 callback=lambda _: do_greeting(
@@ -382,9 +407,130 @@ def greet_new_chat_members(update: Update, context: CallbackContext) -> None:
                     users=users,
                 ),
                 when=(next_possible_greeting_time - dtm.datetime.now()).seconds,
-                name='greetings_job',
+                name="greetings_job",
             )
     else:
         do_greeting(
             bot=context.bot, chat_data=chat_data, group_user_name=group_user_name, users=users
         )
+
+
+def list_available_hints(update: Update, _: CallbackContext) -> None:
+    private = False
+    if cast(Chat, update.effective_chat).type != Chat.PRIVATE:
+        text = "Please use this command in private chat with me."
+        reply_markup: Optional[InlineKeyboardMarkup] = InlineKeyboardMarkup.from_button(
+            InlineKeyboardButton("Take me there!", url=f"https://t.me/{const.SELF_BOT_NAME}")
+        )
+        private = True
+    else:
+        text = "You can use the following tags to guide new members:\n\n"
+        text += "\n".join(
+            f"🗣 {hint.display_name} ➖ {hint.description}" for hint in TAG_HINTS.values()
+        )
+        text += "\n\nMake sure to reply to another message, so I know who to refer to."
+        reply_markup = None
+
+    message = cast(Message, update.effective_message)
+    message.reply_text(
+        text,
+        reply_markup=reply_markup,
+    )
+    if private:
+        message.delete()
+
+
+def tag_hint(update: Update, _: CallbackContext) -> None:
+    message = cast(Message, update.effective_message)
+    reply_to = message.reply_to_message
+
+    messages = []
+    keyboard = None
+    for match in TAG_HINTS_PATTERN.finditer(cast(str, message.text)):
+        hint = TAG_HINTS[match.group(2).lstrip("/")]
+        messages.append(hint.html_markup())
+
+        if entry_kb := hint.inline_keyboard:
+            if keyboard is None:
+                keyboard = entry_kb
+            else:
+                keyboard.inline_keyboard.extend(entry_kb.inline_keyboard)
+
+    effective_text = "\n➖\n".join(messages)
+    message.reply_text(
+        effective_text,
+        reply_markup=keyboard,
+        reply_to_message_id=reply_to.message_id if reply_to else None,
+    )
+
+    if reply_to:
+        message.delete()
+
+
+def say_potato_job(context: CallbackContext) -> None:
+    user_id, message, ban_person = cast(Tuple[int, Message, User], cast(Job, context.job).context)
+    context.bot.ban_chat_member(chat_id=ONTOPIC_CHAT_ID, user_id=user_id)
+    context.bot.ban_chat_member(chat_id=OFFTOPIC_CHAT_ID, user_id=user_id)
+
+    text = (
+        "You have been banned for userbot-like behavior. If you are not a userbot and wish to be"
+        f"unbanned, please contact {ban_person.mention_html()}."
+    )
+    message.edit_text(text=text)
+
+
+def say_potato_button(update: Update, context: CallbackContext) -> None:
+    callback_query = cast(CallbackQuery, update.callback_query)
+    _, user_id, correct = cast(str, callback_query.data).split()
+
+    if callback_query.from_user.id != user_id:
+        callback_query.answer(
+            text="This button is obviously not meant for you. 😉", show_alert=True
+        )
+        return
+
+    jobs = cast(JobQueue, context.job_queue).get_jobs_by_name(f"POTATO {user_id}")
+    if not jobs:
+        return
+    job = jobs[0]
+
+    if correct == "True":
+        callback_query.answer(
+            text="Thanks for the verification! Have fun in the group 🙂", show_alert=True
+        )
+    else:
+        callback_query.answer(text="That was wrong. Ciao! 👋", show_alert=True)
+        job.run(context.dispatcher)
+
+    job.schedule_removal()
+
+
+def say_potato_command(update: Update, context: CallbackContext) -> None:
+    message = cast(Message, update.effective_message)
+    message.delete()
+
+    if not message.reply_to_message:
+        return
+
+    user = cast(User, message.reply_to_message.from_user)
+    time_limit = (int(context.args[0]) if context.args else None) or 60
+    correct, incorrect_1, incorrect_2 = random.sample(VEGETABLES, 3)
+
+    message_text = (
+        f"You display behavior that is common for userbots, i.e. automated Telegram "
+        f"accounts that usually produce spam. Please verify that you are not a userbot by "
+        f"clicking the button that says {correct}. If you don't press the button within "
+        f"{time_limit} minutes, you will be banned from the PTB groups. If you miss the "
+        f"time limit but are not a userbot and want to get unbanned, please contact "
+        f"{cast(User, message.from_user).mention_html()}."
+    )
+
+    answers = random.sample([(correct, True), (incorrect_1, False), (incorrect_2, False)], 3)
+    keyboard = InlineKeyboardMarkup.from_row(
+        [
+            InlineKeyboardButton(text=veg, callback_data=f"POTATO {user.id} {truth}")
+            for veg, truth in answers
+        ]
+    )
+
+    message.reply_to_message.reply_text(message_text, reply_markup=keyboard)

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -30,6 +30,7 @@ from components.const import (
     OFFTOPIC_RULES_MESSAGE_LINK,
     NEW_CHAT_MEMBERS_LIMIT_SPACING,
 )
+from components.entrytypes import BaseEntry
 from components.util import (
     rate_limit,
     get_reply_id,
@@ -236,7 +237,7 @@ def github(update: Update, context: CallbackContext) -> None:
     message = cast(Message, update.effective_message)
     last = 0.0
     thing_matches = []
-    things = {}
+    things: List[BaseEntry] = []
 
     for match in GITHUB_PATTERN.finditer(get_text_not_in_entities(message.text_html)):
         logging.debug(match.groupdict())
@@ -252,21 +253,21 @@ def github(update: Update, context: CallbackContext) -> None:
         if number:
             issue = github_issues.get_issue(int(number), owner, repo)
             if issue is not None:
-                things[issue.url] = github_issues.pretty_format_issue(issue)
+                things.append(issue)
         elif sha:
             commit = github_issues.get_commit(sha, owner, repo)
             if commit is not None:
-                things[commit.url] = github_issues.pretty_format_commit(commit)
+                things.append(commit)
         elif ptbcontrib:
             contrib = github_issues.ptbcontribs.get(ptbcontrib)
             if contrib:
-                things[contrib.url] = f'ptbcontrib/{contrib.name}'
+                things.append(contrib)
 
     if things:
         reply_or_edit(
             update,
             context,
-            '\n'.join([f'<a href="{url}">{name}</a>' for url, name in things.items()]),
+            '\n'.join([thing.html_markup for thing in things]),
         )
 
 

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -4,6 +4,7 @@ import logging
 import time
 from collections import deque
 import random
+from copy import deepcopy
 from typing import cast, Match, List, Dict, Any, Optional, Tuple
 
 from telegram import (
@@ -445,7 +446,7 @@ def tag_hint(update: Update, _: CallbackContext) -> None:
         # Merge keyboards into one
         if entry_kb := hint.inline_keyboard:
             if keyboard is None:
-                keyboard = entry_kb
+                keyboard = deepcopy(entry_kb)
             else:
                 keyboard.inline_keyboard.extend(entry_kb.inline_keyboard)
 

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -99,7 +99,7 @@ def inlinequery_entity_parsing(update: Update, _: CallbackContext) -> None:
         "of reserved characters, please see the official "
         "<a href='https://core.telegram.org/bots/api#html-style'>Telegram docs</a>."
     )
-    cast(Message, update.message).reply_text(text)
+    cast(Message, update.effective_message).reply_text(text)
 
 
 @rate_limit

--- a/components/const.py
+++ b/components/const.py
@@ -13,9 +13,8 @@ RATE_LIMIT_SPACING = 2
 NEW_CHAT_MEMBERS_LIMIT_SPACING = 60
 USER_AGENT = 'Github: python-telegram-bot/rules-bot'
 ENCLOSING_REPLACEMENT_CHARACTER = '+'
-ENCLOSED_REGEX = (
-    rf'\{ENCLOSING_REPLACEMENT_CHARACTER}([a-zA-Z_.0-9]*)\{ENCLOSING_REPLACEMENT_CHARACTER}'
-)
+_ERC = ENCLOSING_REPLACEMENT_CHARACTER
+ENCLOSED_REGEX = rf'\{_ERC}([^{_ERC}]*)\{_ERC}'
 OFFTOPIC_USERNAME = 'pythontelegrambottalk'
 ONTOPIC_USERNAME = 'pythontelegrambotgroup'
 OFFTOPIC_CHAT_ID = '@' + OFFTOPIC_USERNAME
@@ -118,7 +117,7 @@ GITHUB_PATTERN = re.compile(
                     (?:  # Followed by either
                         (?P<number>\d+)  # Numbers
                         |  # Or
-                        (?P<query>\S+)  # A search query (without spaces) (only works inline)
+                        (?P<query>.+)  # A search query (only works inline)
                     )
                 )
             |  # Or

--- a/components/const.py
+++ b/components/const.py
@@ -1,40 +1,40 @@
 import re
 from urllib.parse import urljoin
 
-ARROW_CHARACTER = '➜'
+ARROW_CHARACTER = "➜"
 GITHUB_URL = "https://github.com/"
-DEFAULT_REPO_OWNER = 'python-telegram-bot'
-DEFAULT_REPO_NAME = 'python-telegram-bot'
-PTBCONTRIB_REPO_NAME = 'ptbcontrib'
-DEFAULT_REPO = f'{DEFAULT_REPO_OWNER}/{DEFAULT_REPO_NAME}'
+DEFAULT_REPO_OWNER = "python-telegram-bot"
+DEFAULT_REPO_NAME = "python-telegram-bot"
+PTBCONTRIB_REPO_NAME = "ptbcontrib"
+DEFAULT_REPO = f"{DEFAULT_REPO_OWNER}/{DEFAULT_REPO_NAME}"
 # Require x non-command messages between each /rules etc.
 RATE_LIMIT_SPACING = 2
 # Welcome new chat members at most ever X minutes
 NEW_CHAT_MEMBERS_LIMIT_SPACING = 60
-USER_AGENT = 'Github: python-telegram-bot/rules-bot'
-ENCLOSING_REPLACEMENT_CHARACTER = '+'
+USER_AGENT = "Github: python-telegram-bot/rules-bot"
+ENCLOSING_REPLACEMENT_CHARACTER = "+"
 _ERC = ENCLOSING_REPLACEMENT_CHARACTER
-ENCLOSED_REGEX = rf'\{_ERC}([^{_ERC}]*)\{_ERC}'
-OFFTOPIC_USERNAME = 'pythontelegrambottalk'
-ONTOPIC_USERNAME = 'pythontelegrambotgroup'
-OFFTOPIC_CHAT_ID = '@' + OFFTOPIC_USERNAME
-ONTOPIC_CHAT_ID = '@' + ONTOPIC_USERNAME
+ENCLOSED_REGEX = re.compile(rf"\{_ERC}([^{_ERC}]*)\{_ERC}")
+OFFTOPIC_USERNAME = "pythontelegrambottalk"
+ONTOPIC_USERNAME = "pythontelegrambotgroup"
+OFFTOPIC_CHAT_ID = "@" + OFFTOPIC_USERNAME
+ONTOPIC_CHAT_ID = "@" + ONTOPIC_USERNAME
 ERROR_CHANNEL_CHAT_ID = -1001397960657
-TELEGRAM_SUPERSCRIPT = 'ᵀᴱᴸᴱᴳᴿᴬᴹ'
-FAQ_CHANNEL_ID = '@ptbfaq'
-SELF_BOT_NAME = 'roolsbot'
+TELEGRAM_SUPERSCRIPT = "ᵀᴱᴸᴱᴳᴿᴬᴹ"
+FAQ_CHANNEL_ID = "@ptbfaq"
+SELF_BOT_NAME = "roolsbot"
 ONTOPIC_RULES_MESSAGE_ID = 419903
-ONTOPIC_RULES_MESSAGE_LINK = 'https://t.me/pythontelegrambotgroup/419903'
+ONTOPIC_RULES_MESSAGE_LINK = "https://t.me/pythontelegrambotgroup/419903"
 OFFTOPIC_RULES_MESSAGE_ID = 161133
-OFFTOPIC_RULES_MESSAGE_LINK = 'https://t.me/pythontelegrambottalk/161133'
-PTBCONTRIB_LINK = 'https://github.com/python-telegram-bot/ptbcontrib/'
+OFFTOPIC_RULES_MESSAGE_LINK = "https://t.me/pythontelegrambottalk/161133"
+PTBCONTRIB_LINK = "https://github.com/python-telegram-bot/ptbcontrib/"
 DOCS_URL = "https://python-telegram-bot.readthedocs.io/en/stable/"
 OFFICIAL_URL = "https://core.telegram.org/bots/api"
-PROJECT_URL = urljoin(GITHUB_URL, DEFAULT_REPO + '/')
+PROJECT_URL = urljoin(GITHUB_URL, DEFAULT_REPO + "/")
 WIKI_URL = urljoin(PROJECT_URL, "wiki/")
 WIKI_CODE_SNIPPETS_URL = urljoin(WIKI_URL, "Code-snippets")
 WIKI_FAQ_URL = urljoin(WIKI_URL, "Frequently-Asked-Questions")
-EXAMPLES_URL = urljoin(PROJECT_URL, 'tree/master/examples/')
+EXAMPLES_URL = urljoin(PROJECT_URL, "tree/master/examples/")
 ONTOPIC_RULES = """
 This group is for questions, answers and discussions around the \
 <a href="https://python-telegram-bot.org/">python-telegram-bot library</a> and, to some extent, \
@@ -53,6 +53,7 @@ conversation with them.
 - Please abide by our <a href="https://github.com/python-telegram-bot/python-telegram-bot/blob/\
 master/CODE_OF_CONDUCT.md">Code of Conduct</a>
 - Use <code>@admin</code> to report spam or abuse and <i>only</i> for that.
+- If you have a userbot, deactivate it in here. Otherwise you'll get banned at least temporarily.
 
 Before asking, please take a look at our <a href="https://github.com/python-telegram-bot/\
 python-telegram-bot/wiki">wiki</a> and <a href="https://github.com/python-telegram-bot/\
@@ -80,6 +81,7 @@ conversation with them.
 - Please abide by our <a href="https://github.com/python-telegram-bot/python-telegram-bot/blob/\
 master/CODE_OF_CONDUCT.md">Code of Conduct</a>
 - Use <code>@admin</code> to report spam or abuse and <i>only</i> for that.
+- If you have a userbot, deactivate it in here. Otherwise you'll get banned at least temporarily.
 """
 
 # Github Pattern
@@ -130,3 +132,87 @@ GITHUB_PATTERN = re.compile(
 """,
     re.VERBOSE,
 )
+VEGETABLES = [
+    "amaranth",
+    "anise",
+    "artichoke",
+    "arugula",
+    "asparagus",
+    "aubergine",
+    "basil",
+    "beet",
+    "broccoflower",
+    "broccoli",
+    "cabbage",
+    "calabrese",
+    "caraway",
+    "carrot",
+    "cauliflower",
+    "celeriac",
+    "celery",
+    "chamomile",
+    "chard",
+    "chayote",
+    "chickpea",
+    "chives",
+    "cilantro",
+    "corn",
+    "corn salad",
+    "courgette",
+    "cucumber",
+    "daikon",
+    "delicata",
+    "dill",
+    "eggplant",
+    "endive",
+    "fennel",
+    "fiddlehead",
+    "frisee",
+    "garlic",
+    "ginger",
+    "habanero",
+    "horseradish",
+    "jalapeno",
+    "jicama",
+    "kale",
+    "kohlrabi",
+    "lavender",
+    "leek ",
+    "legume",
+    "lentils",
+    "lettuce",
+    "mamey",
+    "mangetout",
+    "marjoram",
+    "mushroom",
+    "nopale",
+    "okra",
+    "onion",
+    "oregano",
+    "paprika",
+    "parsley",
+    "parsnip",
+    "pea",
+    "potato",
+    "pumpkin",
+    "radicchio",
+    "radish",
+    "rhubarb",
+    "rosemary",
+    "rutabaga",
+    "sage",
+    "scallion",
+    "shallot",
+    "skirret",
+    "spinach",
+    "squash",
+    "taro",
+    "thyme",
+    "topinambur",
+    "tubers",
+    "turnip",
+    "wasabi",
+    "watercress",
+    "yam",
+    "zucchini",
+]

--- a/components/entrytypes.py
+++ b/components/entrytypes.py
@@ -496,9 +496,15 @@ class TagHint(BaseEntry):
         return self._description
 
     def html_markup(self, search_query: str = None) -> str:
-        return self._message.format(
-            query=search_query.split(maxsplit=1)[-1] if search_query else self._default_query
-        )
+        if not search_query:
+            insertion = self._default_query
+        else:
+            query_parts = search_query.split(maxsplit=1)
+            if len(query_parts) == 1 and self.short_name.startswith(query_parts[0]):
+                insertion = self._default_query
+            else:
+                insertion = query_parts[-1]
+        return self._message.format(query=insertion)
 
     def html_insertion_markup(self, search_query: str = None) -> str:
         return self.html_markup(search_query=search_query)

--- a/components/entrytypes.py
+++ b/components/entrytypes.py
@@ -1,0 +1,448 @@
+import re
+from abc import ABC, abstractmethod
+from typing import List
+
+from github3.repos.commit import RepoCommit as GHCommit
+from github3.repos import Repository as GHRepo
+from github3.issues import Issue as GHIssue
+from fuzzywuzzy import fuzz
+
+from components.const import (
+    ARROW_CHARACTER,
+    TELEGRAM_SUPERSCRIPT,
+    DEFAULT_REPO_OWNER,
+    DEFAULT_REPO_NAME,
+)
+
+
+class BaseEntry(ABC):
+    """Base class for all searchable entries."""
+
+    @property
+    @abstractmethod
+    def display_name(self) -> str:
+        """Name to display in the search results"""
+
+    @property
+    def short_name(self) -> str:
+        """Potentially shorter name name to display. Defaults to :attr:`display_name`"""
+        return self.display_name
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Description of the entry to display in the search results"""
+
+    @property
+    @abstractmethod
+    def html_markup(self) -> str:
+        """HTML markup to be used if this entry is selected in the search"""
+
+    @property
+    @abstractmethod
+    def html_insertion_markup(self) -> str:
+        """HTML markup to be used for insertion search"""
+
+    @abstractmethod
+    def compare_to_query(self, search_query: str) -> float:
+        """Gives a number ∈[0,100] describing how similar the search query is to this entry."""
+
+
+class Example(BaseEntry):
+    """An example in the examples directory.
+
+    Args:
+        name: The name of the example
+        url: URL of the example
+    """
+
+    def __init__(self, name: str, url: str):
+        if name.endswith('.py'):
+            self._name = name[:-3]
+        else:
+            self._name = name
+        self.url = url
+
+    @property
+    def display_name(self) -> str:
+        return f'Examples {ARROW_CHARACTER} {self._name}'
+
+    @property
+    def short_name(self) -> str:
+        return f'{self._name}.py'
+
+    @property
+    def description(self) -> str:
+        return 'Examples directory of python-telegram-bot'
+
+    @property
+    def html_markup(self) -> str:
+        return f'Examples directory of <i>python-telegram-bot</i>:\n{self.html_insertion_markup}'
+
+    @property
+    def html_insertion_markup(self) -> str:
+        return f'<a href="{self.url}">{self.short_name}</a>'
+
+    def compare_to_query(self, search_query: str) -> float:
+        if search_query.endswith('.py'):
+            search_query = search_query[:-3]
+
+        search_query = search_query.replace(' ', '')
+        return fuzz.partial_ratio(self._name, search_query)
+
+
+class WikiPage(BaseEntry):
+    """A wiki page.
+
+    Args:
+        category: The .py of the page, as listed in the sidebar
+        name: The name of the page
+        url: URL of the page
+    """
+
+    def __init__(self, category: str, name: str, url: str):
+        self.category = category
+        self.name = name
+        self.url = url
+        self._compare_name = f'{self.category} {self.name}'
+
+    @property
+    def display_name(self) -> str:
+        return f'{self.category} {ARROW_CHARACTER} {self.name}'
+
+    @property
+    def short_name(self) -> str:
+        return self.name
+
+    @property
+    def description(self) -> str:
+        return 'Wiki of python-telegram-bot'
+
+    @property
+    def html_markup(self) -> str:
+        return (
+            f'Wiki of <i>python-telegram-bot</i> - Category <i>{self.category}</i>\n'
+            f'{self.html_insertion_markup}'
+        )
+
+    @property
+    def html_insertion_markup(self) -> str:
+        return f'<a href="{self.url}">{self.short_name}</a>'
+
+    def compare_to_query(self, search_query: str) -> float:
+        return fuzz.token_set_ratio(self._compare_name, search_query)
+
+
+class CodeSnippet(WikiPage):
+    """A code snippet
+
+    Args:
+        name: The name of the snippet
+        url: URL of the snippet
+    """
+
+    def __init__(self, name: str, url: str):
+        super().__init__(category='Code Snippets', name=name, url=url)
+
+
+class FAQEntry(WikiPage):
+    """An FAQ entry
+
+    Args:
+        name: The name of the entry
+        url: URL of the entry
+    """
+
+    def __init__(self, name: str, url: str):
+        super().__init__(category='FAQ', name=name, url=url)
+
+
+class DocEntry(BaseEntry):
+    """An entry to the PTB docs.
+
+    Args:
+        url: URL to the online documentation of the entry.
+        entry_type: Which type of entry this is.
+        name: Name of the entry.
+        display_name: Optional. Display name for the entry.
+        telegram_name: Optional: Name of the corresponding Telegram documentation entry.
+        telegram_url: Optional. Link to the corresponding Telegram documentation.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        entry_type: str,
+        name: str,
+        display_name: str = None,
+        telegram_name: str = None,
+        telegram_url: str = None,
+    ):
+        self.url = url
+        self.entry_type = entry_type
+        self.effective_type = self.entry_type.split(':')[-1]
+        self.name = name
+        self._display_name = display_name
+        self.telegram_url = telegram_url
+        self.telegram_name = telegram_name
+        self._parsed_name: List[str] = self.parse_search_query(self.name)
+
+    @staticmethod
+    def parse_search_query(search_query: str) -> List[str]:
+        """
+        Does some preprocessing of the query needed for comparison with the entries in the docs.
+
+        Args:
+            search_query: The search query.
+
+        Returns:
+            The query, split on ``.``, ``-`` and ``/``, in reversed order.
+        """
+        # reversed, so that 'class' matches the 'class' part of 'module.class' exactly instead of
+        # not matching the 'module' part
+        return list(reversed(re.split(r'\.|/|-', search_query.strip())))
+
+    @property
+    def display_name(self) -> str:
+        name = self._display_name or self.name
+        return name.replace('filters.', '')
+
+    @property
+    def short_name(self) -> str:
+        name = self._display_name or self.name
+
+        if name.startswith('telegram.ext.filters.'):
+            return f"ext.{name[len('telegram.ext.filters.') :]}"
+        if name.startswith('telegram.'):
+            return name[len('telegram.') :]
+        return name
+
+    @property
+    def description(self) -> str:
+        return 'Documentation of python-telegram-bot'
+
+    @property
+    def html_markup(self) -> str:
+        base = (
+            f'<code>{self.short_name}</code>\n'
+            f'<i>python-telegram-bot</i> documentation for this {self.effective_type}:\n'
+            f'{self.html_markup_no_telegram}'
+        )
+        if not self.telegram_url and not self.telegram_name:
+            tg_text = ''
+        else:
+            tg_text = (
+                '\n\nTelegrams official Bot API documentation has more info about'
+                f'<a href="{self.telegram_url}">{self.telegram_name}</a>'
+            )
+        return base + tg_text
+
+    @property
+    def html_markup_no_telegram(self) -> str:
+        return f'<a href="{self.url}">{self.short_name}</a>'
+
+    @property
+    def html_insertion_markup(self) -> str:
+        if not self.telegram_name and not self.telegram_url:
+            return self.html_markup_no_telegram
+        return (
+            f'{self.html_markup_no_telegram} <a href="{self.telegram_url}">'
+            f'{TELEGRAM_SUPERSCRIPT}</a>'
+        )
+
+    def compare_to_query(self, search_query: str) -> float:
+        score = 0.0
+        processed_query = self.parse_search_query(search_query)
+
+        # We compare all the single parts of the query …
+        for target, value in zip(processed_query, self._parsed_name):
+            score += fuzz.ratio(target, value)
+        # ... and the full name because we're generous
+        score += fuzz.ratio(search_query, self.name)
+
+        # IISC std: is the domain for general stuff like headlines and chapters.
+        # we'll wanna give those a little less weight
+        if self.entry_type.startswith('std:'):
+            score *= 0.8
+        return score
+
+
+class Commit(BaseEntry):
+    """A commit on Github
+
+    Args:
+        commit: The github3 commit object
+        repository: The github3 repository object
+    """
+
+    def __init__(self, commit: GHCommit, repository: GHRepo) -> None:
+        self._commit = commit
+        self._repository = repository
+
+    @property
+    def owner(self) -> str:
+        return self._repository.owner.login
+
+    @property
+    def repo(self) -> str:
+        return self._repository.name
+
+    @property
+    def sha(self) -> str:
+        return self._commit.sha
+
+    @property
+    def short_sha(self) -> str:
+        return self.sha[:7]
+
+    @property
+    def url(self) -> str:
+        return self._commit.html_url
+
+    @property
+    def title(self) -> str:
+        return self._commit.commit['message']
+
+    @property
+    def author(self) -> str:
+        return self._commit.author['login']
+
+    @property
+    def short_name(self) -> str:
+        return (
+            f'{"" if self.owner == DEFAULT_REPO_OWNER else self.owner + "/"}'
+            f'{"" if self.repo == DEFAULT_REPO_NAME else self.repo}'
+            f'@{self.short_sha}'
+        )
+
+    @property
+    def display_name(self) -> str:
+        return f'Commit {self.short_name}: {self.title} by {self.author}'
+
+    @property
+    def description(self) -> str:
+        return 'Search on GitHub'
+
+    @property
+    def html_markup(self) -> str:
+        return f'<a href="{self.display_name}">{self.url}</a>'
+
+    @property
+    def html_insertion_markup(self) -> str:
+        return f'<a href="{self.short_name}">{self.url}</a>'
+
+    def compare_to_query(self, search_query: str) -> float:
+        search_query = search_query.lstrip('@ ')
+        if self.sha.startswith(search_query):
+            return 100
+        return 0
+
+
+class Issue(BaseEntry):
+    """An issue/PR on Github
+
+    Args:
+        issue: The github3 issue object
+        repository: The github3 repository object
+    """
+
+    def __init__(self, issue: GHIssue, repository: GHRepo) -> None:
+        self._issue = issue
+        self._repository = repository
+
+    @property
+    def type(self) -> str:
+        return 'Issue' if not self._issue.pull_request_urls else 'PR'
+
+    @property
+    def owner(self) -> str:
+        return self._repository.owner.login
+
+    @property
+    def repo(self) -> str:
+        return self._repository.name
+
+    @property
+    def number(self) -> int:
+        return self._issue.number
+
+    @property
+    def url(self) -> str:
+        return self._issue.html_url
+
+    @property
+    def title(self) -> str:
+        return self._issue.title
+
+    @property
+    def author(self) -> str:
+        return self._issue.user.login
+
+    @property
+    def short_name(self) -> str:
+        return (
+            f'{"" if self.owner == DEFAULT_REPO_OWNER else self.owner + "/"}'
+            f'{"" if self.repo == DEFAULT_REPO_NAME else self.repo}'
+            f'#{self.number}'
+        )
+
+    @property
+    def display_name(self) -> str:
+        return f'{self.type} {self.short_name}: {self.title} by {self.author}'
+
+    @property
+    def description(self) -> str:
+        return 'Search on GitHub'
+
+    @property
+    def html_markup(self) -> str:
+        return f'<a href="{self.url}">{self.display_name}</a>'
+
+    @property
+    def html_insertion_markup(self) -> str:
+        return f'<a href="{self.url}">{self.short_name}</a>'
+
+    def compare_to_query(self, search_query: str) -> float:
+        search_query = search_query.lstrip('# ')
+        if str(self.number) == search_query:
+            return 100
+        return fuzz.token_set_ratio(self.title, search_query)
+
+
+class PTBContrib(BaseEntry):
+    """A contribution of ptbcontrib
+
+    Args:
+        name: The name of the contribution
+        url: The url to the contribution
+    """
+
+    def __init__(self, name: str, url: str):
+        self.name = name
+        self.url = url
+
+    @property
+    def display_name(self) -> str:
+        return f'ptbcontrib/{self.name}'
+
+    @property
+    def short_name(self) -> str:
+        return self.display_name
+
+    @property
+    def description(self) -> str:
+        return 'Community base extensions for python-telegram-bot'
+
+    @property
+    def html_markup(self) -> str:
+        return f'<a href="{self.url}">{self.display_name}</a>'
+
+    @property
+    def html_insertion_markup(self) -> str:
+        return self.html_markup
+
+    def compare_to_query(self, search_query: str) -> float:
+        # Here we just assume that everything before thi first / is ptbcontrib
+        # (modulo typos). That could be wrong, but then it's the users fault :)
+        search_query = search_query.split('/', maxsplit=1)[-1]
+        return fuzz.ratio(self.name, search_query)

--- a/components/entrytypes.py
+++ b/components/entrytypes.py
@@ -242,7 +242,7 @@ class DocEntry(BaseEntry):
             tg_text = ""
         else:
             tg_text = (
-                "\n\nTelegram's official Bot API documentation has more info about"
+                "\n\nTelegram's official Bot API documentation has more info about "
                 f'<a href="{self.telegram_url}">{self.telegram_name}</a>.'
             )
         return base + tg_text
@@ -333,7 +333,7 @@ class Commit(BaseEntry):
         return "Search on GitHub"
 
     def html_markup(self, _: str = None) -> str:
-        return f'<a href="{self.display_name}">{self.url}</a>'
+        return f'<a href="{self.url}">{self.display_name}</a>'
 
     def html_insertion_markup(self, _: str = None) -> str:
         return f'<a href="{self.url}">{self.short_name}</a>'
@@ -403,8 +403,11 @@ class Issue(BaseEntry):
 
     @property
     def short_description(self) -> str:
+        # Needs to be here because of cyclical imports
+        from .util import truncate_str  # pylint:disable=import-outside-toplevel
+
         string = f"{self.type} {self.short_name}: {self.title}"
-        return (string[:25] + "…") if len(string) > 25 else string
+        return truncate_str(string, 25)
 
     def html_markup(self, _: str = None) -> str:
         return f'<a href="{self.url}">{self.display_name}</a>'

--- a/components/entrytypes.py
+++ b/components/entrytypes.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from github3.repos.commit import RepoCommit as GHCommit
 from github3.repos import Repository as GHRepo
 from github3.issues import Issue as GHIssue
-from fuzzywuzzy import fuzz
+from thefuzz import fuzz
 from telegram import InlineKeyboardMarkup
 
 from components.const import (
@@ -26,7 +26,7 @@ class BaseEntry(ABC):
 
     @property
     def short_name(self) -> str:
-        """Potentially shorter name name to display. Defaults to :attr:`display_name`"""
+        """Potentially shorter name to display. Defaults to :attr:`display_name`"""
         return self.display_name
 
     @property
@@ -36,7 +36,7 @@ class BaseEntry(ABC):
 
     @property
     def short_description(self) -> str:
-        """Short description of the entry ot display in the search results. Useful when displaying
+        """Short description of the entry to display in the search results. Useful when displaying
         multiple search results in one entry. Defaults to :attr:`short_name` if not overridden."""
         return self.short_name
 
@@ -242,7 +242,7 @@ class DocEntry(BaseEntry):
             tg_text = ""
         else:
             tg_text = (
-                "\n\nTelegrams official Bot API documentation has more info about"
+                "\n\nTelegram's official Bot API documentation has more info about"
                 f'<a href="{self.telegram_url}">{self.telegram_name}</a>.'
             )
         return base + tg_text
@@ -336,7 +336,7 @@ class Commit(BaseEntry):
         return f'<a href="{self.display_name}">{self.url}</a>'
 
     def html_insertion_markup(self, _: str = None) -> str:
-        return f'<a href="{self.short_name}">{self.url}</a>'
+        return f'<a href="{self.url}">{self.short_name}</a>'
 
     def compare_to_query(self, search_query: str) -> float:
         search_query = search_query.lstrip("@ ")
@@ -434,10 +434,6 @@ class PTBContrib(BaseEntry):
     @property
     def display_name(self) -> str:
         return f"ptbcontrib/{self.name}"
-
-    @property
-    def short_name(self) -> str:
-        return self.display_name
 
     @property
     def description(self) -> str:

--- a/components/entrytypes.py
+++ b/components/entrytypes.py
@@ -73,6 +73,7 @@ class Example(BaseEntry):
             self._name = name[:-3]
         else:
             self._name = name
+        self._search_name = f"example {self._name}".lower()
         self.url = url
 
     @property
@@ -100,8 +101,7 @@ class Example(BaseEntry):
         if search_query.endswith(".py"):
             search_query = search_query[:-3]
 
-        search_query = search_query.replace(" ", "")
-        return fuzz.partial_ratio(self._name.lower(), search_query.lower())
+        return fuzz.partial_token_set_ratio(self._search_name, search_query.lower())
 
 
 class WikiPage(BaseEntry):
@@ -268,6 +268,8 @@ class DocEntry(BaseEntry):
             score += fuzz.ratio(target.lower(), value.lower())
         # ... and the full name because we're generous
         score += fuzz.ratio(search_query.lower(), self.name.lower())
+        # To stay <= 100 as not to overrule other results
+        score = score / 2
 
         # IISC std: is the domain for general stuff like headlines and chapters.
         # we'll wanna give those a little less weight

--- a/components/errorhandler.py
+++ b/components/errorhandler.py
@@ -23,16 +23,16 @@ def error_handler(update: object, context: CallbackContext) -> None:
     tb_list = traceback.format_exception(
         None, context.error, cast(Exception, context.error).__traceback__
     )
-    tb_string = ''.join(tb_list)
+    tb_string = "".join(tb_list)
 
     # Build the message with some markup and additional information about what happened.
     # You might need to add some logic to deal with messages longer than the 4096 character limit.
     update_str = update.to_dict() if isinstance(update, Update) else str(update)
     message_1 = (
-        f'An exception was raised while handling an update\n\n'
-        f'<pre>update = {html.escape(json.dumps(update_str, indent=2, ensure_ascii=False))}</pre>'
+        f"An exception was raised while handling an update\n\n"
+        f"<pre>update = {html.escape(json.dumps(update_str, indent=2, ensure_ascii=False))}</pre>"
     )
-    message_2 = f'<pre>{html.escape(tb_string)}</pre>'
+    message_2 = f"<pre>{html.escape(tb_string)}</pre>"
 
     # Finally, send the messages
     # We send update and traceback in two parts to reduce the chance of hitting max length
@@ -40,10 +40,10 @@ def error_handler(update: object, context: CallbackContext) -> None:
         sent_message = context.bot.send_message(chat_id=ERROR_CHANNEL_CHAT_ID, text=message_1)
         sent_message.reply_html(message_2)
     except BadRequest as exc:
-        if 'too long' in str(exc):
+        if "too long" in str(exc):
             message = (
-                f'Hey.\nThe error <code>{html.escape(str(context.error))}</code> happened.'
-                f' The traceback is too long to send, but it was written to the log.'
+                f"Hey.\nThe error <code>{html.escape(str(context.error))}</code> happened."
+                f" The traceback is too long to send, but it was written to the log."
             )
             context.bot.send_message(chat_id=ERROR_CHANNEL_CHAT_ID, text=message)
         else:

--- a/components/github.py
+++ b/components/github.py
@@ -80,7 +80,7 @@ class GitHubIssues:
     def get_issue(self, number: int, owner: str = None, repo: str = None) -> Optional[Issue]:
         if owner or repo:
             self.logger.info(
-                'Getting issue %d for %s/%s',
+                "Getting issue %d for %s/%s",
                 number,
                 owner or self.default_owner,
                 repo or self.default_repo,
@@ -112,7 +112,7 @@ class GitHubIssues:
     ) -> Optional[Commit]:
         if owner or repo:
             self.logger.info(
-                'Getting commit %s for %s/%s',
+                "Getting commit %s for %s/%s",
                 sha[:7],
                 owner or self.default_owner,
                 repo or self.default_repo,
@@ -134,12 +134,12 @@ class GitHubIssues:
             return None
 
     def _job(self, job_queue: JobQueue) -> None:
-        self.logger.info('Getting issues for default repo.')
+        self.logger.info("Getting issues for default repo.")
 
         try:
             repo = self.repos[self.default_repo]
             if self.issue_iterator is None:
-                self.issue_iterator = self.repos[self.default_repo].issues(state='all')
+                self.issue_iterator = self.repos[self.default_repo].issues(state="all")
             else:
                 # The GitHubIterator automatically takes care of passing the ETag
                 # which reduces the number of API requests that count towards the rate limit
@@ -156,18 +156,18 @@ class GitHubIssues:
                 # uses. sleeping doesn't block the bot, as jobs run in their own thread.
                 # This is outside the lock! (see above commit)
                 if (i + 1) % 100 == 0:
-                    self.logger.info('Done with %d issues. Sleeping a moment.', i + 1)
+                    self.logger.info("Done with %d issues. Sleeping a moment.", i + 1)
                     time.sleep(10)
 
             # Rerun in 20 minutes
             job_queue.run_once(lambda _: self._job(job_queue), 60 * 20)
         except GitHubException as exc:
-            if 'rate limit' in str(exc):
-                self.logger.warning('GH API rate limit exceeded. Retrying in 70 minutes.')
+            if "rate limit" in str(exc):
+                self.logger.warning("GH API rate limit exceeded. Retrying in 70 minutes.")
                 job_queue.run_once(lambda _: self._job(job_queue), 60 * 70)
             else:
                 self.logger.exception(
-                    'Something went wrong fetching issues. Retrying in 10s.', exc_info=exc
+                    "Something went wrong fetching issues. Retrying in 10s.", exc_info=exc
                 )
                 job_queue.run_once(lambda _: self._job(job_queue), 10)
 
@@ -175,7 +175,7 @@ class GitHubIssues:
         job_queue.run_once(lambda _: self._job(job_queue), 10)
 
     def _ptbcontrib_job(self, job_queue: JobQueue) -> None:
-        self.logger.info('Getting ptbcontrib data.')
+        self.logger.info("Getting ptbcontrib data.")
 
         try:
             files = cast(
@@ -188,19 +188,19 @@ class GitHubIssues:
                     {
                         name: PTBContrib(name, content.html_url)
                         for name, content in files
-                        if content.type == 'dir'
+                        if content.type == "dir"
                     }
                 )
 
             # Rerun in two hours minutes
             job_queue.run_once(lambda _: self._ptbcontrib_job(job_queue), 2 * 60 * 60)
         except GitHubException as exc:
-            if 'rate limit' in str(exc):
-                self.logger.warning('GH API rate limit exceeded. Retrying in 70 minutes.')
+            if "rate limit" in str(exc):
+                self.logger.warning("GH API rate limit exceeded. Retrying in 70 minutes.")
                 job_queue.run_once(lambda _: self._ptbcontrib_job(job_queue), 60 * 70)
             else:
                 self.logger.exception(
-                    'Something went wrong fetching issues. Retrying in 10s.', exc_info=exc
+                    "Something went wrong fetching issues. Retrying in 10s.", exc_info=exc
                 )
                 job_queue.run_once(lambda _: self._ptbcontrib_job(job_queue), 10)
 
@@ -219,7 +219,7 @@ class GitHubIssues:
 
         files = cast(
             List[Tuple[str, Contents]],
-            self.repos[self.default_repo].directory_contents('examples'),
+            self.repos[self.default_repo].directory_contents("examples"),
         )
         if effective_pattern is None:
             return [(name, self._build_example_url(name)) for name, _ in files]

--- a/components/inlinequeries.py
+++ b/components/inlinequeries.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import cast
 from uuid import uuid4
 
@@ -40,7 +41,7 @@ def inline_query(update: Update, _: CallbackContext) -> None:  # pylint: disable
     query = ilq.query
     switch_pm_text = "❓ Help"
 
-    if ENCLOSED_REGEX.match(query):
+    if ENCLOSED_REGEX.search(query):
         results_list = []
         symbols = tuple(ENCLOSED_REGEX.findall(query))
         search_results = search.multi_search_combinations(symbols)
@@ -58,9 +59,10 @@ def inline_query(update: Update, _: CallbackContext) -> None:  # pylint: disable
                 )
                 if isinstance(entry, Issue):
                     index.append(entry.html_markup(symbol))
+                # Merge keyboards into one
                 if entry_kb := entry.inline_keyboard:
                     if not keyboard:
-                        keyboard = entry_kb
+                        keyboard = deepcopy(entry_kb)
                     else:
                         keyboard.inline_keyboard.extend(entry_kb.inline_keyboard)
 
@@ -86,6 +88,7 @@ def inline_query(update: Update, _: CallbackContext) -> None:  # pylint: disable
                     title=entry.display_name,
                     description=entry.description,
                     message_text=entry.html_markup(query),
+                    reply_markup=entry.inline_keyboard,
                 )
                 for entry in simple_search_results
             ]

--- a/components/inlinequeries.py
+++ b/components/inlinequeries.py
@@ -1,7 +1,5 @@
 import re
-from collections import OrderedDict
-from html import escape
-from typing import List, cast, Tuple, Optional, no_type_check, Union, Dict
+from typing import cast
 from uuid import uuid4
 
 from telegram import (
@@ -10,21 +8,16 @@ from telegram import (
     Update,
     InlineQuery,
     InlineKeyboardMarkup,
+    ParseMode,
 )
 from telegram.error import BadRequest
 from telegram.ext import InlineQueryHandler, CallbackContext, Dispatcher
 
-from components import taghints
 from components.const import (
     ENCLOSED_REGEX,
-    TELEGRAM_SUPERSCRIPT,
     ENCLOSING_REPLACEMENT_CHARACTER,
-    GITHUB_PATTERN,
-    ARROW_CHARACTER,
-    WIKI_URL,
 )
 from components.search import search
-from components.github import Commit, github_issues, Issue, PTBContrib
 
 
 def article(
@@ -38,372 +31,256 @@ def article(
         id=key or str(uuid4()),
         title=title,
         description=description,
-        input_message_content=InputTextMessageContent(message_text=message_text),
+        input_message_content=InputTextMessageContent(
+            message_text=message_text, parse_mode=ParseMode.HTML
+        ),
         reply_markup=reply_markup,
     )
 
 
-def fuzzy_replacements_html(
-    query: str, threshold: int = 95, official_api_links: bool = True
-) -> Tuple[Optional[List[str]], Optional[str]]:
-    """Replaces the enclosed characters in the query string with hyperlinks
-    to the documentations."""
-    symbols = re.findall(ENCLOSED_REGEX, query)
-
-    if not symbols:
-        return None, None
-
-    replacements = list()
-    for symbol in symbols:
-        # Wiki first, cause with docs you can always prepend telegram. for better precision
-        wiki = search.wiki(symbol.replace('_', ' '), amount=1, threshold=threshold)
-        if wiki:
-            name = wiki[0][0].split(ARROW_CHARACTER)[-1].strip()
-            text = f'<a href="{wiki[0][1]}">{name}</a>'
-            replacements.append((wiki[0][0], symbol, text))
-            continue
-
-        doc = search.docs(symbol, threshold=threshold)
-        if doc:
-            text = f'<a href="{doc.url}">{doc.short_name}</a>'
-
-            if doc.tg_url and official_api_links:
-                text += f' <a href="{doc.tg_url}">{TELEGRAM_SUPERSCRIPT}</a>'
-
-            replacements.append((doc.short_name, symbol, text))
-            continue
-
-        # not found
-        replacements.append((symbol + '❓', symbol, escape(symbol)))
-
-    result = query
-    for name, symbol, text in replacements:
-        char = ENCLOSING_REPLACEMENT_CHARACTER
-        result = result.replace(f'{char}{symbol}{char}', text)
-
-    if not result:
-        return None, None
-
-    result_changed = [x[0] for x in replacements]
-    return result_changed, result
+# def fuzzy_replacements_html(query: str) -> Tuple[Optional[List[str]], Optional[str]]:
+#     """Replaces the enclosed characters in the query string with hyperlinks
+#     to the documentations."""
+#     symbols = re.findall(ENCLOSED_REGEX, query)
+#
+#     if not symbols:
+#         return None, None
+#
+#     replacements = list()
+#     for symbol in symbols:
+#         # Wiki first, cause with docs you can always prepend telegram. for better precision
+#         wiki = search.wiki(symbol.replace('_', ' '), amount=1, threshold=threshold)
+#         if wiki:
+#             name = wiki[0][0].split(ARROW_CHARACTER)[-1].strip()
+#             text = f'<a href="{wiki[0][1]}">{name}</a>'
+#             replacements.append((wiki[0][0], symbol, text))
+#             continue
+#
+#         doc = search.docs(symbol, threshold=threshold)
+#         if doc:
+#             text = f'<a href="{doc.url}">{doc.short_name}</a>'
+#
+#             if doc.tg_url and official_api_links:
+#                 text += f' <a href="{doc.tg_url}">{TELEGRAM_SUPERSCRIPT}</a>'
+#
+#             replacements.append((doc.short_name, symbol, text))
+#             continue
+#
+#         # not found
+#         replacements.append((symbol + '❓', symbol, escape(symbol)))
+#
+#     result = query
+#     for name, symbol, text in replacements:
+#         char = ENCLOSING_REPLACEMENT_CHARACTER
+#         result = result.replace(f'{char}{symbol}{char}', text)
+#
+#     if not result:
+#         return None, None
+#
+#     result_changed = [x[0] for x in replacements]
+#     return result_changed, result
 
 
-@no_type_check
-def unwrap(things):
-    """
-    Unwrap and collapse things
-    [1,(2,3),4,(5,6),7] into [[1,2,4,5,7], [1,2,4,6,7]]
-    Where lists are actually dicts, tuples are actually search results,
-    and numbers are Issues/PRs/Commits
-    """
-    last_search = [None]
+#
+#
+# @no_type_check
+# def unwrap(things):
+#     """
+#     Unwrap and collapse things
+#     [1,(2,3),4,(5,6),7] into [[1,2,4,5,7], [1,2,4,6,7]]
+#     Where lists are actually dicts, tuples are actually search results,
+#     and numbers are Issues/PRs/Commits
+#     """
+#     last_search = [None]
+#
+#     for k, candidate in reversed(things.items()):
+#         if not isinstance(candidate, (Issue, Commit, PTBContrib)):
+#             last_search = candidate
+#             break
+#
+#     out = [OrderedDict() for _ in last_search]
+#
+#     for k, elem_merged in things.items():
+#         if elem_merged is last_search:
+#             for i, elem_last in enumerate(elem_merged):
+#                 out[i][k] = elem_last
+#         elif not isinstance(elem_merged, (Issue, Commit, PTBContrib)):
+#             for i, _ in enumerate(out):
+#                 out[i][k] = elem_merged[0]
+#         else:
+#             for i, _ in enumerate(out):
+#                 out[i][k] = elem_merged
+#
+#     return last_search, out
+#
+#
+# def inline_github(query: str) -> List[InlineQueryResultArticle]:
+#     """
+#     Parse query for issues, PRs and commits SHA
+#     Returns a list of `articles`.
+#
+#     Examples:
+#         `ptbcontrib/search` - [(title=🔍 A contrib with search in its description,
+#                                 description=ptbcontrib/that contrib), …]
+#         `#10` - [(title=Replace via GitHub,
+#                  description=#10: tenth issue title)]
+#         `#10 #9` - [(title=Replace via GitHub,
+#                     description=#10: tenth issue title, #9: ninth issue)]
+#         `@d6d0dec6e0e8b647d140dfb74db66ecb1d00a61d` - [(title=Replace via GitHub,
+#                                                         description=@d6d0dec: commit title)]
+#         `#search` - [(title= 🔍 An issue with search in it's issue,
+#                       description=#3: that issue),
+#                      (title= 🔍 Another issue with search in it's issue,
+#                       description=#2: that issue),
+#                      ... (3 more)]
+#         `#10 #search` - [(title=An issue with search in it's issue,
+#                           description=#10: tenth issue, #3: that issue),
+#                          (title=Another issue with search in it's issue,
+#                           description=#10: tenth issue, #2: that issue),
+#                          ... (3 more)]
+#         `#search #10` - [(title= 🔍 An issue with search in it's issue,
+#                           description=#3: that issue, #10: tenth issue),
+#                          (title= 🔍 Another issue with search in it's issue,
+#                           description=#2: that issue, #10, tenth issue),
+#                          ... (3 more)]
+#         `#search1 #10 #search2` - [(title= 🔍 An issue with search2 in it's issue,
+#                                     description=#3: search1 result, #10: tenth issue,
+#                                     #5: search2 result1),
+#                                    (title= 🔍 Another issue with search2 in it's issue,
+#                                     description=#3: search1 result, #10, tenth issue,
+#                                     #6: search2 result2), ... (3 more)]
+#     """
+#     # Issues/PRs/Commits
+#     things: Dict[
+#         str, Union[Issue, Commit, List[Issue], PTBContrib, List[PTBContrib]]
+#     ] = OrderedDict()
+#     results = []
+#
+#     # Search for Issues, PRs and commits in the query and add them to things
+#     for match in GITHUB_PATTERN.finditer(query):
+#         owner, repo, number, sha, search_query, full, ptbcontrib = [
+#             match.groupdict()[x]
+#             for x in ('owner', 'repo', 'number', 'sha', 'query', 'full', 'ptbcontrib')
+#         ]
+#         # If it's an issue
+#         if number:
+#             issue = github_issues.get_issue(int(number), owner, repo)
+#             if issue:
+#                 things[full] = issue
+#         # If it's a commit
+#         elif sha:
+#             commit = github_issues.get_commit(sha, owner, repo)
+#             if commit:
+#                 things[full] = commit
+#         # If it's a search
+#         elif search_query:
+#             search_results = github_issues.search(search_query)
+#             things['#' + search_query] = search_results
+#         elif ptbcontrib:
+#             contrib = github_issues.ptbcontribs.get(ptbcontrib)
+#             if contrib is not None:
+#                 things[full] = contrib
+#             else:
+#                 contrib_search_results = github_issues.search_ptbcontrib(ptbcontrib)
+#                 things[full] = contrib_search_results
+#
+#     if not things:
+#         # We didn't find anything
+#         return []
+#
+#     # Unwrap and collapse things
+#     last_search, choices = unwrap(things)
+#
+#     # Loop over all the choices we should send to the client
+#     # Each choice (items) is a dict of things (issues/PRs/commits) to show in that choice
+#     # If not searching there will only be a single choice
+#     # If searching we have 5 different possibilities we wanna send
+#     for i, items in enumerate(choices):
+#         # If we did a search
+#         if last_search and last_search[i]:
+#             # Show the search title as the title
+#             title = '🔍' + github_issues.pretty_format(
+#                 last_search[i], short_with_title=True, title_max_length=50
+#             )
+#         else:
+#             # Otherwise just use generic title
+#             title = 'Resolve via GitHub'
+#
+#         # Description is the short formats combined with ', '
+#         description = ', '.join(
+#             github_issues.pretty_format(thing, short_with_title=True) for thing in items.values()
+#         )
+#
+#         # Truncate the description to 100 chars, from the left side.
+#         # So the last thing will always be shown.
+#         if len(description) > 100:
+#             description = '⟻' + description[-99:].partition(',')[2]
+#
+#         # The text that will be sent when user clicks the choice/result
+#         text = ''
+#         pattern = r'|'.join(
+#             re.escape(thing) for thing in sorted(items.keys(), key=len, reverse=True)
+#         )
+#         # Check if there's other stuff than issues/PRs etc. in the query by
+#         # removing issues/PRs etc. and seeing if there's anything left
+#         if re.sub(pattern, '', query).strip():
+#             # Replace every 'thing' with a link to said thing *all at once*
+#             # Needs to all at once because otherwise 'blah/blah#2 #2'
+#             # would break would turn into something like
+#             # [blah/blah[#2](LinkFor#2)](LinkForblah/blah[#2](LinkFor#2))
+#             # which isn't even valid markdown
+#             text = re.sub(
+#                 pattern,
+#                 lambda x: f'<a href="{items[x.group(0)].url}">'  # pylint: disable=W0640
+#                 f'{github_issues.pretty_format(items[x.group(0)], short=True)}</a>',
+#                 query,
+#             )
+#
+#         # Add full format to bottom of message
+#         text += '\n\n' + '\n'.join(
+#             f'<a href="{thing.url}">{github_issues.pretty_format(thing)}</a>'
+#             for thing in items.values()
+#         )
+#
+#         results.append(article(title=title, description=description, message_text=text))
+#
+#     return results
 
-    for k, candidate in reversed(things.items()):
-        if not isinstance(candidate, (Issue, Commit, PTBContrib)):
-            last_search = candidate
-            break
 
-    out = [OrderedDict() for _ in last_search]
-
-    for k, elem_merged in things.items():
-        if elem_merged is last_search:
-            for i, elem_last in enumerate(elem_merged):
-                out[i][k] = elem_last
-        elif not isinstance(elem_merged, (Issue, Commit, PTBContrib)):
-            for i, _ in enumerate(out):
-                out[i][k] = elem_merged[0]
-        else:
-            for i, _ in enumerate(out):
-                out[i][k] = elem_merged
-
-    return last_search, out
-
-
-def inline_github(query: str) -> List[InlineQueryResultArticle]:
-    """
-    Parse query for issues, PRs and commits SHA
-    Returns a list of `articles`.
-
-    Examples:
-        `ptbcontrib/search` - [(title=🔍 A contrib with search in its description,
-                                description=ptbcontrib/that contrib), …]
-        `#10` - [(title=Replace via GitHub,
-                 description=#10: tenth issue title)]
-        `#10 #9` - [(title=Replace via GitHub,
-                    description=#10: tenth issue title, #9: ninth issue)]
-        `@d6d0dec6e0e8b647d140dfb74db66ecb1d00a61d` - [(title=Replace via GitHub,
-                                                        description=@d6d0dec: commit title)]
-        `#search` - [(title= 🔍 An issue with search in it's issue,
-                      description=#3: that issue),
-                     (title= 🔍 Another issue with search in it's issue,
-                      description=#2: that issue),
-                     ... (3 more)]
-        `#10 #search` - [(title=An issue with search in it's issue,
-                          description=#10: tenth issue, #3: that issue),
-                         (title=Another issue with search in it's issue,
-                          description=#10: tenth issue, #2: that issue),
-                         ... (3 more)]
-        `#search #10` - [(title= 🔍 An issue with search in it's issue,
-                          description=#3: that issue, #10: tenth issue),
-                         (title= 🔍 Another issue with search in it's issue,
-                          description=#2: that issue, #10, tenth issue),
-                         ... (3 more)]
-        `#search1 #10 #search2` - [(title= 🔍 An issue with search2 in it's issue,
-                                    description=#3: search1 result, #10: tenth issue,
-                                    #5: search2 result1),
-                                   (title= 🔍 Another issue with search2 in it's issue,
-                                    description=#3: search1 result, #10, tenth issue,
-                                    #6: search2 result2), ... (3 more)]
-    """
-    # Issues/PRs/Commits
-    things: Dict[
-        str, Union[Issue, Commit, List[Issue], PTBContrib, List[PTBContrib]]
-    ] = OrderedDict()
-    results = []
-
-    # Search for Issues, PRs and commits in the query and add them to things
-    for match in GITHUB_PATTERN.finditer(query):
-        owner, repo, number, sha, search_query, full, ptbcontrib = [
-            match.groupdict()[x]
-            for x in ('owner', 'repo', 'number', 'sha', 'query', 'full', 'ptbcontrib')
-        ]
-        # If it's an issue
-        if number:
-            issue = github_issues.get_issue(int(number), owner, repo)
-            if issue:
-                things[full] = issue
-        # If it's a commit
-        elif sha:
-            commit = github_issues.get_commit(sha, owner, repo)
-            if commit:
-                things[full] = commit
-        # If it's a search
-        elif search_query:
-            search_results = github_issues.search(search_query)
-            things['#' + search_query] = search_results
-        elif ptbcontrib:
-            contrib = github_issues.ptbcontribs.get(ptbcontrib)
-            if contrib is not None:
-                things[full] = contrib
-            else:
-                contrib_search_results = github_issues.search_ptbcontrib(ptbcontrib)
-                things[full] = contrib_search_results
-
-    if not things:
-        # We didn't find anything
-        return []
-
-    # Unwrap and collapse things
-    last_search, choices = unwrap(things)
-
-    # Loop over all the choices we should send to the client
-    # Each choice (items) is a dict of things (issues/PRs/commits) to show in that choice
-    # If not searching there will only be a single choice
-    # If searching we have 5 different possibilities we wanna send
-    for i, items in enumerate(choices):
-        # If we did a search
-        if last_search and last_search[i]:
-            # Show the search title as the title
-            title = '🔍' + github_issues.pretty_format(
-                last_search[i], short_with_title=True, title_max_length=50
-            )
-        else:
-            # Otherwise just use generic title
-            title = 'Resolve via GitHub'
-
-        # Description is the short formats combined with ', '
-        description = ', '.join(
-            github_issues.pretty_format(thing, short_with_title=True) for thing in items.values()
-        )
-
-        # Truncate the description to 100 chars, from the left side.
-        # So the last thing will always be shown.
-        if len(description) > 100:
-            description = '⟻' + description[-99:].partition(',')[2]
-
-        # The text that will be sent when user clicks the choice/result
-        text = ''
-        pattern = r'|'.join(
-            re.escape(thing) for thing in sorted(items.keys(), key=len, reverse=True)
-        )
-        # Check if there's other stuff than issues/PRs etc. in the query by
-        # removing issues/PRs etc. and seeing if there's anything left
-        if re.sub(pattern, '', query).strip():
-            # Replace every 'thing' with a link to said thing *all at once*
-            # Needs to all at once because otherwise 'blah/blah#2 #2'
-            # would break would turn into something like
-            # [blah/blah[#2](LinkFor#2)](LinkForblah/blah[#2](LinkFor#2))
-            # which isn't even valid markdown
-            text = re.sub(
-                pattern,
-                lambda x: f'<a href="{items[x.group(0)].url}">'  # pylint: disable=W0640
-                f'{github_issues.pretty_format(items[x.group(0)], short=True)}</a>',
-                query,
-            )
-
-        # Add full format to bottom of message
-        text += '\n\n' + '\n'.join(
-            f'<a href="{thing.url}">{github_issues.pretty_format(thing)}</a>'
-            for thing in items.values()
-        )
-
-        results.append(article(title=title, description=description, message_text=text))
-
-    return results
-
-
-def inline_query(  # pylint: disable=R0915
-    update: Update, _: CallbackContext, threshold: int = 15
-) -> None:
-    query = cast(InlineQuery, update.inline_query).query
-    results_list = list()
-
-    if len(query) > 0:
-        if query.startswith('#'):
-            hints = taghints.get_hints(query, full_match=False)
-            results_list.extend(
-                [
-                    article(
-                        f'Send hint on {key.capitalize()}',
-                        hint.help,
-                        hint.msg,
-                        key=key,
-                        reply_markup=hint.reply_markup,
-                    )
-                    for key, hint in hints.items()
-                ]
-            )
-
-        if '#' in query or '@' in query or 'ptbcontrib/' in query:
-            results_list.extend(inline_github(query))
-
-        if ENCLOSING_REPLACEMENT_CHARACTER in query:
-            modified, replaced = fuzzy_replacements_html(query, official_api_links=True)
-            if modified:
-                assert replaced is not None  # for mypy
-                results_list.append(
-                    article(
-                        title="Replace links and show official Bot API documentation",
-                        description=', '.join(modified),
-                        message_text=replaced,
-                    )
-                )
-
-            modified, replaced = fuzzy_replacements_html(query, official_api_links=False)
-            if modified:
-                assert replaced is not None  # for mypy
-                results_list.append(
-                    article(
-                        title="Replace links",
-                        description=', '.join(modified),
-                        message_text=replaced,
-                    )
-                )
-
-        if query.lower() == 'faq':
-            for name, link in search.all_faq():
-                results_list.append(
-                    article(
-                        title=name,
-                        description='Wiki of python-telegram-bot',
-                        message_text=f'Wiki of <i>python-telegram-bot</i>\n'
-                        f'<a href="{link}">{escape(name)}</a>',
-                    )
-                )
-        if query.lower().startswith('faq') and len(query.split(' ')) > 1:
-            faq = search.faq(query.split(' ', 1)[1], amount=20, threshold=threshold)
-            if faq:
-                for question in faq:
-                    results_list.append(
-                        article(
-                            title=f'{question[0]}',
-                            description="Github wiki for python-telegram-bot",
-                            message_text=f'Wiki of <i>python-telegram-bot</i>\n'
-                            f'<a href="{question[1]}">{question[0]}</a>',
-                        )
-                    )
-
-        if query.lower() == 'snippets':
-            for name, link in search.all_code_snippets():
-                results_list.append(
-                    article(
-                        title=name,
-                        description='Wiki of python-telegram-bot',
-                        message_text=f'Wiki of <i>python-telegram-bot</i>\n'
-                        f'<a href="{link}">{escape(name)}</a>',
-                    )
-                )
-        if query.lower().startswith('snippets') and len(query.split(' ')) > 1:
-            snippets = search.code_snippets(query.split(' ', 1)[1], amount=20, threshold=threshold)
-            if snippets:
-                for snippet in snippets:
-                    results_list.append(
-                        article(
-                            title=f'{snippet[0]}',
-                            description="Github wiki for python-telegram-bot",
-                            message_text=f'Wiki of <i>python-telegram-bot</i>\n'
-                            f'<a href="{snippet[1]}">{snippet[0]}</a>',
-                        )
-                    )
-
-        # If no results so far then search wiki and docs
-        if not results_list:
-            doc = search.docs(query, threshold=threshold)
-            if doc:
-                text = (
-                    f'<b>{doc.short_name}</b>\n'
-                    f'<i>python-telegram-bot</i> documentation for this {doc.type}:\n'
-                    f'<a href="{doc.url}">{doc.full_name}</a>'
-                )
-                if doc.tg_name:
-                    text += (
-                        f'\n\nThe official documentation has more info about '
-                        f'<a href="{doc.tg_url}">{doc.tg_name}</a>. '
-                    )
-
-                results_list.append(
-                    article(
-                        title=f'{doc.full_name}',
-                        description="python-telegram-bot documentation",
-                        message_text=text,
-                    )
-                )
-
-            wiki_pages = search.wiki(query, amount=4, threshold=threshold)
-            if wiki_pages:
-                for wiki_page in wiki_pages:
-                    results_list.append(
-                        article(
-                            title=f'{wiki_page[0]}',
-                            description="Github wiki for python-telegram-bot",
-                            message_text=f'Wiki of <i>python-telegram-bot</i>\n'
-                            f'<a href="{wiki_page[1]}">{wiki_page[0]}</a>',
-                        )
-                    )
-
-        # If no results even after searching wiki and docs
-        if not results_list:
-            results_list.append(
-                article(
-                    title='❌ No results.',
-                    description='',
-                    message_text=f'<a href="{WIKI_URL}">GitHub wiki</a> of '
-                    f'<i>python-telegram-bot</i>',
-                )
-            )
-
-    else:
-        for name, link in search.all_wiki_pages():
-            results_list.append(
-                article(
-                    title=name,
-                    description='Wiki of python-telegram-bot',
-                    message_text=f'Wiki of <i>python-telegram-bot</i>\n'
-                    f'<a href="{link}">{escape(name)}</a>',
-                )
-            )
-
+def inline_query(update: Update, _: CallbackContext) -> None:  # pylint: disable=R0915
     ilq = cast(InlineQuery, update.inline_query)
+    query = ilq.query
+
+    if ENCLOSING_REPLACEMENT_CHARACTER in query:
+        results_list = []
+        symbols = tuple(re.findall(ENCLOSED_REGEX, query))
+        search_results = search.multi_search_combinations(symbols)
+        for combination in search_results:
+            description = ', '.join(entry.short_name for entry in combination.values())
+            message_text = query
+            for symbol, entry in combination.items():
+                char = ENCLOSING_REPLACEMENT_CHARACTER
+                message_text = message_text.replace(
+                    f'{char}{symbol}{char}', entry.html_insertion_markup
+                )
+
+            results_list.append(
+                article(
+                    title='Insert links into message',
+                    description=description,
+                    message_text=message_text,
+                )
+            )
+    else:
+        results_list = [
+            article(
+                title=entry.display_name,
+                description=entry.description,
+                message_text=entry.html_markup,
+            )
+            for entry in search.search(query)
+        ]
+
     try:
         ilq.answer(
             results=results_list,
@@ -413,13 +290,14 @@ def inline_query(  # pylint: disable=R0915
             auto_pagination=True,
         )
     except BadRequest as exc:
-        if "can't parse entities" not in exc.message:
-            raise exc
-        ilq.answer(
-            results=[],
-            switch_pm_text='❌ Invalid entities. Click me.',
-            switch_pm_parameter='inline-entity-parsing',
-        )
+        print(exc)
+        # if "can't parse entities" not in exc.message:
+        #     raise exc
+        # ilq.answer(
+        #     results=[],
+        #     switch_pm_text='❌ Invalid entities. Click me.',
+        #     switch_pm_parameter='inline-entity-parsing',
+        # )
 
 
 def register(dispatcher: Dispatcher) -> None:

--- a/components/inlinequeries.py
+++ b/components/inlinequeries.py
@@ -1,4 +1,3 @@
-import re
 from typing import cast
 from uuid import uuid4
 
@@ -8,22 +7,22 @@ from telegram import (
     Update,
     InlineQuery,
     InlineKeyboardMarkup,
-    ParseMode,
 )
 from telegram.error import BadRequest
-from telegram.ext import InlineQueryHandler, CallbackContext, Dispatcher
+from telegram.ext import CallbackContext
 
 from components.const import (
     ENCLOSED_REGEX,
     ENCLOSING_REPLACEMENT_CHARACTER,
 )
+from components.entrytypes import Issue
 from components.search import search
 
 
 def article(
-    title: str = '',
-    description: str = '',
-    message_text: str = '',
+    title: str = "",
+    description: str = "",
+    message_text: str = "",
     key: str = None,
     reply_markup: InlineKeyboardMarkup = None,
 ) -> InlineQueryResultArticle:
@@ -31,274 +30,79 @@ def article(
         id=key or str(uuid4()),
         title=title,
         description=description,
-        input_message_content=InputTextMessageContent(
-            message_text=message_text, parse_mode=ParseMode.HTML
-        ),
+        input_message_content=InputTextMessageContent(message_text=message_text),
         reply_markup=reply_markup,
     )
-
-
-# def fuzzy_replacements_html(query: str) -> Tuple[Optional[List[str]], Optional[str]]:
-#     """Replaces the enclosed characters in the query string with hyperlinks
-#     to the documentations."""
-#     symbols = re.findall(ENCLOSED_REGEX, query)
-#
-#     if not symbols:
-#         return None, None
-#
-#     replacements = list()
-#     for symbol in symbols:
-#         # Wiki first, cause with docs you can always prepend telegram. for better precision
-#         wiki = search.wiki(symbol.replace('_', ' '), amount=1, threshold=threshold)
-#         if wiki:
-#             name = wiki[0][0].split(ARROW_CHARACTER)[-1].strip()
-#             text = f'<a href="{wiki[0][1]}">{name}</a>'
-#             replacements.append((wiki[0][0], symbol, text))
-#             continue
-#
-#         doc = search.docs(symbol, threshold=threshold)
-#         if doc:
-#             text = f'<a href="{doc.url}">{doc.short_name}</a>'
-#
-#             if doc.tg_url and official_api_links:
-#                 text += f' <a href="{doc.tg_url}">{TELEGRAM_SUPERSCRIPT}</a>'
-#
-#             replacements.append((doc.short_name, symbol, text))
-#             continue
-#
-#         # not found
-#         replacements.append((symbol + '❓', symbol, escape(symbol)))
-#
-#     result = query
-#     for name, symbol, text in replacements:
-#         char = ENCLOSING_REPLACEMENT_CHARACTER
-#         result = result.replace(f'{char}{symbol}{char}', text)
-#
-#     if not result:
-#         return None, None
-#
-#     result_changed = [x[0] for x in replacements]
-#     return result_changed, result
-
-
-#
-#
-# @no_type_check
-# def unwrap(things):
-#     """
-#     Unwrap and collapse things
-#     [1,(2,3),4,(5,6),7] into [[1,2,4,5,7], [1,2,4,6,7]]
-#     Where lists are actually dicts, tuples are actually search results,
-#     and numbers are Issues/PRs/Commits
-#     """
-#     last_search = [None]
-#
-#     for k, candidate in reversed(things.items()):
-#         if not isinstance(candidate, (Issue, Commit, PTBContrib)):
-#             last_search = candidate
-#             break
-#
-#     out = [OrderedDict() for _ in last_search]
-#
-#     for k, elem_merged in things.items():
-#         if elem_merged is last_search:
-#             for i, elem_last in enumerate(elem_merged):
-#                 out[i][k] = elem_last
-#         elif not isinstance(elem_merged, (Issue, Commit, PTBContrib)):
-#             for i, _ in enumerate(out):
-#                 out[i][k] = elem_merged[0]
-#         else:
-#             for i, _ in enumerate(out):
-#                 out[i][k] = elem_merged
-#
-#     return last_search, out
-#
-#
-# def inline_github(query: str) -> List[InlineQueryResultArticle]:
-#     """
-#     Parse query for issues, PRs and commits SHA
-#     Returns a list of `articles`.
-#
-#     Examples:
-#         `ptbcontrib/search` - [(title=🔍 A contrib with search in its description,
-#                                 description=ptbcontrib/that contrib), …]
-#         `#10` - [(title=Replace via GitHub,
-#                  description=#10: tenth issue title)]
-#         `#10 #9` - [(title=Replace via GitHub,
-#                     description=#10: tenth issue title, #9: ninth issue)]
-#         `@d6d0dec6e0e8b647d140dfb74db66ecb1d00a61d` - [(title=Replace via GitHub,
-#                                                         description=@d6d0dec: commit title)]
-#         `#search` - [(title= 🔍 An issue with search in it's issue,
-#                       description=#3: that issue),
-#                      (title= 🔍 Another issue with search in it's issue,
-#                       description=#2: that issue),
-#                      ... (3 more)]
-#         `#10 #search` - [(title=An issue with search in it's issue,
-#                           description=#10: tenth issue, #3: that issue),
-#                          (title=Another issue with search in it's issue,
-#                           description=#10: tenth issue, #2: that issue),
-#                          ... (3 more)]
-#         `#search #10` - [(title= 🔍 An issue with search in it's issue,
-#                           description=#3: that issue, #10: tenth issue),
-#                          (title= 🔍 Another issue with search in it's issue,
-#                           description=#2: that issue, #10, tenth issue),
-#                          ... (3 more)]
-#         `#search1 #10 #search2` - [(title= 🔍 An issue with search2 in it's issue,
-#                                     description=#3: search1 result, #10: tenth issue,
-#                                     #5: search2 result1),
-#                                    (title= 🔍 Another issue with search2 in it's issue,
-#                                     description=#3: search1 result, #10, tenth issue,
-#                                     #6: search2 result2), ... (3 more)]
-#     """
-#     # Issues/PRs/Commits
-#     things: Dict[
-#         str, Union[Issue, Commit, List[Issue], PTBContrib, List[PTBContrib]]
-#     ] = OrderedDict()
-#     results = []
-#
-#     # Search for Issues, PRs and commits in the query and add them to things
-#     for match in GITHUB_PATTERN.finditer(query):
-#         owner, repo, number, sha, search_query, full, ptbcontrib = [
-#             match.groupdict()[x]
-#             for x in ('owner', 'repo', 'number', 'sha', 'query', 'full', 'ptbcontrib')
-#         ]
-#         # If it's an issue
-#         if number:
-#             issue = github_issues.get_issue(int(number), owner, repo)
-#             if issue:
-#                 things[full] = issue
-#         # If it's a commit
-#         elif sha:
-#             commit = github_issues.get_commit(sha, owner, repo)
-#             if commit:
-#                 things[full] = commit
-#         # If it's a search
-#         elif search_query:
-#             search_results = github_issues.search(search_query)
-#             things['#' + search_query] = search_results
-#         elif ptbcontrib:
-#             contrib = github_issues.ptbcontribs.get(ptbcontrib)
-#             if contrib is not None:
-#                 things[full] = contrib
-#             else:
-#                 contrib_search_results = github_issues.search_ptbcontrib(ptbcontrib)
-#                 things[full] = contrib_search_results
-#
-#     if not things:
-#         # We didn't find anything
-#         return []
-#
-#     # Unwrap and collapse things
-#     last_search, choices = unwrap(things)
-#
-#     # Loop over all the choices we should send to the client
-#     # Each choice (items) is a dict of things (issues/PRs/commits) to show in that choice
-#     # If not searching there will only be a single choice
-#     # If searching we have 5 different possibilities we wanna send
-#     for i, items in enumerate(choices):
-#         # If we did a search
-#         if last_search and last_search[i]:
-#             # Show the search title as the title
-#             title = '🔍' + github_issues.pretty_format(
-#                 last_search[i], short_with_title=True, title_max_length=50
-#             )
-#         else:
-#             # Otherwise just use generic title
-#             title = 'Resolve via GitHub'
-#
-#         # Description is the short formats combined with ', '
-#         description = ', '.join(
-#             github_issues.pretty_format(thing, short_with_title=True) for thing in items.values()
-#         )
-#
-#         # Truncate the description to 100 chars, from the left side.
-#         # So the last thing will always be shown.
-#         if len(description) > 100:
-#             description = '⟻' + description[-99:].partition(',')[2]
-#
-#         # The text that will be sent when user clicks the choice/result
-#         text = ''
-#         pattern = r'|'.join(
-#             re.escape(thing) for thing in sorted(items.keys(), key=len, reverse=True)
-#         )
-#         # Check if there's other stuff than issues/PRs etc. in the query by
-#         # removing issues/PRs etc. and seeing if there's anything left
-#         if re.sub(pattern, '', query).strip():
-#             # Replace every 'thing' with a link to said thing *all at once*
-#             # Needs to all at once because otherwise 'blah/blah#2 #2'
-#             # would break would turn into something like
-#             # [blah/blah[#2](LinkFor#2)](LinkForblah/blah[#2](LinkFor#2))
-#             # which isn't even valid markdown
-#             text = re.sub(
-#                 pattern,
-#                 lambda x: f'<a href="{items[x.group(0)].url}">'  # pylint: disable=W0640
-#                 f'{github_issues.pretty_format(items[x.group(0)], short=True)}</a>',
-#                 query,
-#             )
-#
-#         # Add full format to bottom of message
-#         text += '\n\n' + '\n'.join(
-#             f'<a href="{thing.url}">{github_issues.pretty_format(thing)}</a>'
-#             for thing in items.values()
-#         )
-#
-#         results.append(article(title=title, description=description, message_text=text))
-#
-#     return results
 
 
 def inline_query(update: Update, _: CallbackContext) -> None:  # pylint: disable=R0915
     ilq = cast(InlineQuery, update.inline_query)
     query = ilq.query
+    switch_pm_text = "❓ Help"
 
-    if ENCLOSING_REPLACEMENT_CHARACTER in query:
+    if ENCLOSED_REGEX.match(query):
         results_list = []
-        symbols = tuple(re.findall(ENCLOSED_REGEX, query))
+        symbols = tuple(ENCLOSED_REGEX.findall(query))
         search_results = search.multi_search_combinations(symbols)
+
         for combination in search_results:
-            description = ', '.join(entry.short_name for entry in combination.values())
+            description = ", ".join(entry.short_description for entry in combination.values())
             message_text = query
+            index = []
+            keyboard = None
+
             for symbol, entry in combination.items():
                 char = ENCLOSING_REPLACEMENT_CHARACTER
                 message_text = message_text.replace(
-                    f'{char}{symbol}{char}', entry.html_insertion_markup
+                    f"{char}{symbol}{char}", entry.html_insertion_markup(symbol)
                 )
+                if isinstance(entry, Issue):
+                    index.append(entry.html_markup(symbol))
+                if entry_kb := entry.inline_keyboard:
+                    if not keyboard:
+                        keyboard = entry_kb
+                    else:
+                        keyboard.inline_keyboard.extend(entry_kb.inline_keyboard)
+
+            if index:
+                message_text += "\n\n" + "\n".join(index)
 
             results_list.append(
                 article(
-                    title='Insert links into message',
+                    title="Insert links into message",
                     description=description,
                     message_text=message_text,
+                    reply_markup=keyboard,
                 )
             )
     else:
-        results_list = [
-            article(
-                title=entry.display_name,
-                description=entry.description,
-                message_text=entry.html_markup,
-            )
-            for entry in search.search(query)
-        ]
+        simple_search_results = search.search(query)
+        if not simple_search_results:
+            results_list = []
+            switch_pm_text = "❌ No Search Results Found"
+        else:
+            results_list = [
+                article(
+                    title=entry.display_name,
+                    description=entry.description,
+                    message_text=entry.html_markup(query),
+                )
+                for entry in simple_search_results
+            ]
 
     try:
         ilq.answer(
             results=results_list,
-            switch_pm_text='Help',
-            switch_pm_parameter='inline-help',
+            switch_pm_text=switch_pm_text,
+            switch_pm_parameter="inline-help",
             cache_time=0,
             auto_pagination=True,
         )
     except BadRequest as exc:
-        print(exc)
-        # if "can't parse entities" not in exc.message:
-        #     raise exc
-        # ilq.answer(
-        #     results=[],
-        #     switch_pm_text='❌ Invalid entities. Click me.',
-        #     switch_pm_parameter='inline-entity-parsing',
-        # )
-
-
-def register(dispatcher: Dispatcher) -> None:
-    dispatcher.add_handler(InlineQueryHandler(inline_query))
+        if "can't parse entities" not in exc.message:
+            raise exc
+        ilq.answer(
+            results=[],
+            switch_pm_text="❌ Invalid entities. Click me.",
+            switch_pm_parameter="inline-entity-parsing",
+        )

--- a/components/search.py
+++ b/components/search.py
@@ -1,52 +1,36 @@
 import functools
+import heapq
+import itertools
 
 from datetime import date
 
-from collections import OrderedDict, namedtuple
-from typing import TypeVar, Generic, List, Tuple, Optional, Dict, Callable, Any
+from threading import Lock
+from typing import List, Tuple, Dict, Callable, Any, Optional, Iterable, cast
 from urllib.parse import urljoin
 from urllib.request import urlopen, Request
 
 from bs4 import BeautifulSoup
-from fuzzywuzzy import fuzz
 from sphinx.util.inventory import InventoryFile
 
 from .const import (
     USER_AGENT,
-    ARROW_CHARACTER,
     DOCS_URL,
     OFFICIAL_URL,
     WIKI_URL,
     WIKI_CODE_SNIPPETS_URL,
     WIKI_FAQ_URL,
     EXAMPLES_URL,
+    GITHUB_PATTERN,
 )
+from .entrytypes import WikiPage, Example, CodeSnippet, FAQEntry, DocEntry, BaseEntry
 from .github import github_issues
-
-Doc = namedtuple('Doc', 'short_name, full_name, type, url, tg_name, tg_url')
-
-
-Item = TypeVar('Item')
-
-
-class BestHandler(Generic[Item]):
-    def __init__(self) -> None:
-        self.items: List[Tuple[float, Item]] = []
-
-    def add(self, score: float, item: Item) -> None:
-        self.items.append((score, item))
-
-    def to_list(self, amount: int, threshold: float) -> Optional[List[Item]]:
-        items = sorted(self.items, key=lambda x: x[0])
-        effective_items = [item for score, item in reversed(items[-amount:]) if score > threshold]
-        return effective_items if len(effective_items) > 0 else None
 
 
 def cached_parsing(func: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(func)
     def checking_cache_time(self: 'Search', *args: Any, **kwargs: Any) -> Any:
         if date.today() > self.last_cache_date:
-            self.parse()
+            self.fetch_entries()
             self.last_cache_date = date.today()
         return func(self, *args, **kwargs)
 
@@ -55,37 +39,73 @@ def cached_parsing(func: Callable[..., Any]) -> Callable[..., Any]:
 
 class Search:
     def __init__(self) -> None:
-        self._docs: Dict[str, Dict[str, Tuple[str, str, str, str]]] = {}
+        self.__lock = Lock()
+        self._docs: List[DocEntry] = []
         self._official: Dict[str, str] = {}
-        self._wiki: Dict[str, str] = OrderedDict()  # also examples
-        self._snippets: Dict[str, str] = OrderedDict()
-        self._faq: Dict[str, str] = OrderedDict()
+        self._wiki: List[WikiPage] = []
+        self._examples: List[Example] = []
+        self._snippets: List[CodeSnippet] = []
+        self._faq: List[FAQEntry] = []
         self.last_cache_date = date.today()
         self.github_session = github_issues
-        self.parse()
+        self.fetch_entries()
 
-    def parse(self) -> None:
-        self.parse_docs()
-        self.parse_official()
-        # Order matters since we use an ordered dict
-        self.parse_wiki()
-        self.parse_examples()
-        self.parse_wiki_code_snippets()
-        self.parse_wiki_faq()
+    def fetch_entries(self) -> None:
+        with self.__lock:
+            # FIXME: Remove before committing!
+            import ssl
 
-    def parse_docs(self) -> None:
-        request = Request(urljoin(DOCS_URL, "objects.inv"), headers={'User-Agent': USER_AGENT})
-        docs_data = urlopen(request)
-        self._docs = InventoryFile.load(docs_data, DOCS_URL, urljoin)
+            ssl._create_default_https_context = ssl._create_unverified_context
 
-    def parse_official(self) -> None:
+            self.fetch_docs()
+            self.fetch_wiki()
+            self.fetch_examples()
+            self.fetch_wiki_code_snippets()
+            self.fetch_wiki_faq()
+
+            # This is important: If the docs have changed the cache is useless
+            self.search.cache_clear()
+            self.multi_search_combinations.cache_clear()
+
+    def fetch_official_docs(self) -> None:
         request = Request(OFFICIAL_URL, headers={'User-Agent': USER_AGENT})
         official_soup = BeautifulSoup(urlopen(request), "html.parser")
         for anchor in official_soup.select('a.anchor'):
             if '-' not in anchor['href']:
                 self._official[anchor['href'][1:]] = anchor.next_sibling
 
-    def parse_wiki(self) -> None:
+    def fetch_docs(self) -> None:
+        self.fetch_official_docs()
+        request = Request(urljoin(DOCS_URL, "objects.inv"), headers={'User-Agent': USER_AGENT})
+        docs_data = urlopen(request)
+        data = InventoryFile.load(docs_data, DOCS_URL, urljoin)
+        for entry_type, items in data.items():
+            for name, (_, _, url, display_name) in items.items():
+                tg_url, tg_test, tg_name = '', '', ''
+                name_bits = name.split('.')
+
+                if entry_type in ['py:class', 'py:method']:
+                    tg_test = name_bits[-1].replace('_', '').lower()
+                elif entry_type == 'py:attribute':
+                    tg_test = name_bits[-2].replace('_', '').lower()
+
+                if tg_test in self._official.keys():
+                    tg_name = self._official[tg_test]
+                    tg_url = urljoin(OFFICIAL_URL, '#' + tg_name.lower())
+
+                self._docs.append(
+                    DocEntry(
+                        name=name,
+                        url=url,
+                        display_name=display_name if display_name.strip() != '-' else None,
+                        entry_type=entry_type,
+                        telegram_url=tg_url,
+                        telegram_name=tg_name,
+                    )
+                )
+
+    def fetch_wiki(self) -> None:
+        self._wiki = []
         request = Request(WIKI_URL, headers={'User-Agent': USER_AGENT})
         wiki_soup = BeautifulSoup(urlopen(request), "html.parser")
 
@@ -95,127 +115,158 @@ class Search:
                 category = element.find_previous_sibling('h2').text.strip()
                 for list_item in element.select('li'):
                     if list_item.a['href'] != '#':
-                        name = f'{category} {ARROW_CHARACTER} {list_item.a.text.strip()}'
-                        self._wiki[name] = urljoin(WIKI_URL, list_item.a['href'])
+                        self._wiki.append(
+                            WikiPage(
+                                category=category,
+                                name=list_item.a.text.strip(),
+                                url=urljoin(WIKI_URL, list_item.a['href']),
+                            )
+                        )
 
-    def parse_wiki_code_snippets(self) -> None:
+        self._wiki.append(WikiPage(category='Code Resources', name='Examples', url=EXAMPLES_URL))
+
+    def fetch_wiki_code_snippets(self) -> None:
+        self._snippets = []
         request = Request(WIKI_CODE_SNIPPETS_URL, headers={'User-Agent': USER_AGENT})
         code_snippet_soup = BeautifulSoup(urlopen(request), 'html.parser')
         for headline in code_snippet_soup.select(
             'div#wiki-body h4,div#wiki-body h3,div#wiki-body h2'
         ):
-            name = f'Code snippets {ARROW_CHARACTER} {headline.text.strip()}'
-            self._wiki[name] = urljoin(WIKI_CODE_SNIPPETS_URL, headline.a['href'])
-            self._snippets[name] = self._wiki[name]
+            self._snippets.append(
+                CodeSnippet(
+                    name=headline.text.strip(),
+                    url=urljoin(WIKI_CODE_SNIPPETS_URL, headline.a['href']),
+                )
+            )
 
-    def parse_wiki_faq(self) -> None:
+    def fetch_wiki_faq(self) -> None:
+        self._faq = []
         request = Request(WIKI_FAQ_URL, headers={'User-Agent': USER_AGENT})
         code_snippet_soup = BeautifulSoup(urlopen(request), 'html.parser')
         for headline in code_snippet_soup.select('div#wiki-body h3'):
-            name = f'FAQ {ARROW_CHARACTER} {headline.text.strip()}'
-            self._wiki[name] = urljoin(WIKI_FAQ_URL, headline.a['href'])
-            self._faq[name] = self._wiki[name]
+            self._faq.append(
+                FAQEntry(name=headline.text.strip(), url=urljoin(WIKI_FAQ_URL, headline.a['href']))
+            )
 
-    def parse_examples(self) -> None:
-        self._wiki['Examples'] = EXAMPLES_URL
+    def fetch_examples(self) -> None:
+        self._examples = []
         for name, link in self.github_session.get_examples_directory(r'^.*\.py'):
-            self._wiki[f'Examples {ARROW_CHARACTER} {name}'] = link
+            self._examples.append(Example(name=name, url=link))
 
-    @cached_parsing
-    def docs(self, input_query: str, threshold: float = 80) -> Optional[Doc]:
-        query = list(reversed(input_query.split('.')))
-        best: Tuple[float, Optional[Doc]] = (0.0, None)
+    @staticmethod
+    def _sort_key(entry: BaseEntry, search_query: str) -> float:
+        return entry.compare_to_query(search_query)
 
-        for typ, items in self._docs.items():
-            if typ not in [
-                'py:staticmethod',
-                'py:exception',
-                'py:method',
-                'py:module',
-                'py:class',
-                'py:attribute',
-                'py:data',
-                'py:function',
-            ]:
-                continue
-            for name, item in items.items():
-                name_bits = name.split('.')
-                dot_split = zip(query, reversed(name_bits))
-                score = 0.0
-                for target, value in dot_split:
-                    score += fuzz.ratio(target, value)
-                score += fuzz.ratio(query, name)
+    @functools.lru_cache(maxsize=32)
+    def search(self, search_query: Optional[str], amount: int = None) -> Optional[List[BaseEntry]]:
+        """Searches all available entries for appropriate results. This includes:
 
-                # These values are basically random :/
-                if typ == 'py:module':
-                    score *= 0.75
-                if typ == 'py:class':
-                    score *= 1.10
-                if typ == 'py:attribute':
-                    score *= 0.85
+        * wiki pages
+        * FAQ entries
+        * Code snippets
+        * examples
+        * documentation
+        * ptbcontrib
+        * issues & PRs on GH
 
-                if score > best[0]:
-                    tg_url, tg_test, tg_name = '', '', ''
+        If the query is in one of the following formats, the search will *only* attempt to fand
+        one corresponding GitHub result:
 
-                    if typ in ['py:class', 'py:method']:
-                        tg_test = name_bits[-1].replace('_', '').lower()
-                    elif typ == 'py:attribute':
-                        tg_test = name_bits[-2].replace('_', '').lower()
+        * ((owner)/repo)#<issue number>
+        * @<start of sha>
 
-                    if tg_test in self._official.keys():
-                        tg_name = self._official[tg_test]
-                        tg_url = urljoin(OFFICIAL_URL, '#' + tg_name.lower())
+        If the query is in the format `#some search query`, only the issues on
+        python-telegram-bot/python-telegram-bot will be searched.
 
-                    short_name = name_bits[1:]
+        If the query is in the format `ptbcontrib/<name of contribution>`, only the contributions
+        of ptbcontrib will be searched.
 
-                    try:
-                        if name_bits[1].lower() == name_bits[2].lower():
-                            short_name = name_bits[2:]
-                    except IndexError:
-                        pass
-                    best = (
-                        score,
-                        Doc('.'.join(short_name), name, typ[3:], item[2], tg_name, tg_url),
-                    )
-        if best[0] > threshold:
-            return best[1]
-        return None
+        Args:
+            search_query: The search query. May be None, in which case all available entries
+                will be given.
+            amount: Optional. If passed, returns the ``amount`` elements with the highest
+                comparison score.
 
-    @cached_parsing
-    def _get_results(  # pylint: disable=R0201
-        self, candidates: Dict[str, str], query: str, amount: int = 5, threshold: int = 50
-    ) -> Optional[List[Tuple[str, str]]]:
-        best: BestHandler[Tuple[str, str]] = BestHandler()
-        best.add(0, ('HOME', WIKI_URL))
-        if query != '':
-            for name, link in candidates.items():
-                score = fuzz.ratio(query.lower(), name.split(ARROW_CHARACTER)[-1].strip().lower())
-                best.add(score, (name, link))
+        Returns:
+            The results sorted by comparison score.
+        """
+        search_entries: Iterable[BaseEntry] = []
 
-        return best.to_list(amount, threshold)
+        match = GITHUB_PATTERN.fullmatch(search_query) if search_query else None
+        if match:
+            owner, repo, number, sha, gh_search_query, ptbcontrib = [
+                match.groupdict()[x]
+                for x in ('owner', 'repo', 'number', 'sha', 'query', 'ptbcontrib')
+            ]
 
-    def faq(self, query: str, amount: int = 5, threshold: int = 50) -> Optional[List[str]]:
-        return self._get_results(self._faq, query, amount, threshold)
+            # If it's an issue
+            if number:
+                issue = github_issues.get_issue(int(number), owner, repo)
+                return [issue] if issue else None
+            # If it's a commit
+            if sha:
+                commit = github_issues.get_commit(sha, owner, repo)
+                return [commit] if commit else None
+            # If it's a search
+            if gh_search_query:
+                search_query = gh_search_query
+                search_entries = github_issues.all_issues
+            elif ptbcontrib:
+                search_entries = github_issues.all_ptbcontribs
 
-    def code_snippets(
-        self, query: str, amount: int = 5, threshold: int = 50
-    ) -> Optional[List[str]]:
-        return self._get_results(self._snippets, query, amount, threshold)
+        with self.__lock:
+            if not search_entries:
+                search_entries = itertools.chain(
+                    self._wiki,
+                    self._examples,
+                    self._faq,
+                    self._snippets,
+                    github_issues.all_ptbcontribs,
+                    self._docs,
+                )
 
-    def wiki(self, query: str, amount: int = 5, threshold: int = 50) -> Optional[List[str]]:
-        return self._get_results(self._wiki, query, amount, threshold)
+            if not search_query:
+                return search_entries if isinstance(search_entries, list) else list(search_entries)
 
-    @cached_parsing
-    def all_wiki_pages(self) -> List[Tuple[str, str]]:
-        return list(self._wiki.items())
+            if not amount:
+                return sorted(
+                    search_entries,
+                    key=lambda entry: self._sort_key(entry, search_query),  # type: ignore
+                    reverse=True,
+                )
+            return heapq.nlargest(
+                amount,
+                search_entries,
+                key=lambda entry: self._sort_key(entry, search_query),  # type: ignore[arg-type]
+            )
 
-    @cached_parsing
-    def all_code_snippets(self) -> List[Tuple[str, str]]:
-        return list(self._snippets.items())
+    @functools.lru_cache(32)
+    def multi_search_combinations(
+        self, search_queries: Tuple[str], results_per_query: int = 3
+    ) -> List[Dict[str, BaseEntry]]:
+        """For each query, runs :meth:`search` and fetches the ``results_per_query`` most likely
+        results. Then builds all possible combinations.
 
-    @cached_parsing
-    def all_faq(self) -> List[Tuple[str, str]]:
-        return list(self._faq.items())
+        Args:
+            search_queries: The search queries.
+            results_per_query: Optional. Number of results to fetch per query. Defaults to ``3``.
+
+        Returns:
+            All possible result combinations. Each list entry is a dictionary mapping each query
+                to the corresponding :class:`BaseEntry`.
+
+        """
+        # Don't use a page-argument here, as the number of results will usually be relatively small
+        # so we can just build the list once and get slices from the cached result if necessary
+        results = {}
+        for query in search_queries:
+            if res := self.search(search_query=query, amount=results_per_query):
+                results[query] = res
+
+        return [
+            dict(zip(search_queries, query_results))
+            for query_results in itertools.product(*results.values())
+        ]
 
 
 search = Search()

--- a/components/search.py
+++ b/components/search.py
@@ -262,8 +262,8 @@ class Search:
         # so we can just build the list once and get slices from the cached result if necessary
 
         results = {}
-        # Remove duplicates
-        effective_queries = set(search_queries)
+        # Remove duplicates while maintaining the order
+        effective_queries = list(dict.fromkeys(search_queries))
         for query in effective_queries:
             if res := self.search(search_query=query, amount=results_per_query):
                 results[query] = res

--- a/components/taghints.py
+++ b/components/taghints.py
@@ -7,7 +7,29 @@ from components import const
 from components.const import PTBCONTRIB_LINK
 from components.entrytypes import TagHint
 
+# Tag hints should be used for "meta" hints, i.e. pointing out how to use the PTB groups
+# Explaining functionality should be done in the wiki instead.
+#
+# Note that wiki pages are available through the search directly, but the Ask-Right and MWE pages
+# are needed so frequently that we provide tag hints for them ...
 _TAG_HINTS: Dict[str, Dict[str, Any]] = {
+    "askright": {
+        "message": (
+            "{query} In order for someone to be able to help you, you must ask a <b>good "
+            'technical question</b>. Please read <a href="https://github.com/python-telegram-bot/'
+            'python-telegram-bot/wiki/Ask-Right">this short article</a> and try again ;)'
+        ),
+        "help": "The wiki page about asking technical questions",
+        "default": "Hey.",
+    },
+    "mwe": {
+        "message": (
+            '{query} Have a look at <a href="https://telegra.ph/Minimal-Working-Example-for-PTB-'
+            '07-18">this short article</a> for information on what a MWE is.'
+        ),
+        "help": "How to build an MWE for PTB.",
+        "default": "Hey. Please provide a minimal working example (MWE).",
+    },
     "inline": {
         "message": (
             f"Consider using me in inline-mode 😎 <code>@{const.SELF_BOT_NAME} " + "{query}</code>"
@@ -36,25 +58,6 @@ _TAG_HINTS: Dict[str, Dict[str, Any]] = {
         ),
         "help": "What are Userbots?",
         "default": "",
-    },
-    "snippets": {
-        "message": (
-            '<a href="https://github.com/python-telegram-bot/python-telegram-bot/wiki/'
-            'Code-snippets">Here</a> '
-            "you can find many useful code snippets for the work with python-telegram-bot"
-        ),
-        "help": "Link to the wiki's snippets section",
-    },
-    "pprint": {
-        "message": (
-            "The most convenient way of <b>pretty-printing an update</b> is:\n\n"
-            "<pre>from pprint import pprint\npprint(update.to_dict())</pre>\n\n"
-            "It shows you what attributes are available in an update. Alternatively, use a json "
-            "dumping bot like @JsonDumpBot or @JsonDumpBetaBot for a general overview, but keep "
-            "in mind that this method won't be entirely consistent with your bots updates "
-            "(different file_ids for example)."
-        ),
-        "help": "Explain how to pretty-print an update",
     },
     "meta": {
         "message": (
@@ -109,36 +112,10 @@ _TAG_HINTS: Dict[str, Dict[str, Any]] = {
             "library."
         ),
     },
-    "askright": {
-        "message": (
-            "{query} In order for someone to be able to help you, you must ask a <b>good "
-            'technical question</b>. Please read <a href="https://github.com/python-telegram-bot/'
-            'python-telegram-bot/wiki/Ask-Right">this short article</a> and try again ;)'
-        ),
-        "help": "The wiki page about asking technical questions",
-        "default": "Hey.",
-    },
-    "broadcast": {
-        "message": (
-            '{query} Broadcasting to users is a common use case. This <a href="https://telegra.ph/'
-            'Sending-notifications-to-all-users-07-17">short article</a> summarizes the most '
-            "important tips for that."
-        ),
-        "help": "FAQ for broadcasting to users.",
-        "default": "Hey.",
-    },
-    "mwe": {
-        "message": (
-            '{query} Have a look at <a href="https://telegra.ph/Minimal-Working-Example-for-PTB-'
-            '07-18">this short article</a> for information on what a MWE is.'
-        ),
-        "help": "How to build an MWE for PTB.",
-        "default": "Hey. Please provide a minimal working example (MWE).",
-    },
     "pastebin": {
         "message": (
-            "{query} Please post code using a pastebin rather then as plain text or screenshots. "
-            "https://pastebin.com/ is quite popular, but there are many alternatives out there."
+            "{query} Please post code or tracebacks using a pastebin rather then as plain text or."
+            " https://pastebin.com/ is quite popular, but there are many alternatives out there."
             " Of course, for very short snippets, text is fine. Please at least format it as "
             "monospace in that case."
         ),
@@ -152,23 +129,6 @@ _TAG_HINTS: Dict[str, Dict[str, Any]] = {
         ),
         "help": "Ask users not to post the same question in both on- and off-topic.",
         "default": "Hey.",
-    },
-    "formatting": {
-        "message": (
-            "{query} Telegram supports some formatting options for text. All the details about "
-            'what is supported can be found <a href="https://core.telegram.org/bots/api#formatting'
-            '-options">here</a>. You can format text with every API method/type that has a '
-            "<code>parse_mode</code> parameter. In addition to editing your text as described in "
-            "the link above, pass one of the parse modes available through "
-            '<a href="https://python-telegram-bot.readthedocs.io/en/stable/telegram.parsemode.html'
-            '">telegram.ParseMode</a> to the <code>parse_mode</code> parameter. Since the '
-            "<code>5.0</code> update of the Bot API (version <code>13.1+</code> of our library), "
-            'you can alternatively pass a list of <a href="https://python-telegram-bot.'
-            'readthedocs.io/en/stable/telegram.messageentity.html">telegram.MessageEntities</a> '
-            "to the <code>entities</code> parameter."
-        ),
-        "default": "Hey.",
-        "help": "How to use text formatting.",
     },
     "xy": {
         "message": (

--- a/components/taghints.py
+++ b/components/taghints.py
@@ -1,108 +1,101 @@
 import re
-from collections import namedtuple
-from typing import cast, Dict, Optional, TypedDict, List
+from typing import Dict, Any
 
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update, Chat, Message
-from telegram.error import BadRequest
-from telegram.ext import CommandHandler, Filters, MessageHandler, CallbackContext, Dispatcher
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
-from components import const, util
+from components import const
 from components.const import PTBCONTRIB_LINK
+from components.entrytypes import TagHint
 
-
-class HintDictRequired(TypedDict):
-    message: str
-    help: str
-
-
-class HintDict(HintDictRequired, total=False):
-    default: str
-    buttons: List[Dict[str, str]]
-
-
-HINTS: Dict[str, HintDict] = {
-    '#inline': {
-        'message': "Consider using me in inline-mode 😎\n<code>@roolsbot {query}</code>",
-        'default': "Your search terms",
-        'buttons': [{'text': '🔎 Try it out', 'switch_inline_query': '{query}'}],
-        'help': 'Give a query that will be used for a switch_to_inline-button',
+_TAG_HINTS: Dict[str, Dict[str, Any]] = {
+    "inline": {
+        "message": (
+            f"Consider using me in inline-mode 😎 <code>@{const.SELF_BOT_NAME} " + "{query}</code>"
+        ),
+        "default": "Your search terms",
+        "buttons": [[InlineKeyboardButton(text="🔎 Try it out", switch_inline_query="")]],
+        "help": "Give a query that will be used for a switch_to_inline-button",
     },
-    '#private': {
-        'message': "Please don't spam the group with {query}, and go to a private "
+    "private": {
+        "message": "Please don't spam the group with {query}, and go to a private "
         "chat with me instead. Thanks a lot, the other members will appreciate it 😊",
-        'default': 'searches or commands',
-        'buttons': [
-            {'text': '🤖 Go to private chat', 'url': f"https://t.me/{const.SELF_BOT_NAME}"}
+        "default": "searches or commands",
+        "buttons": [
+            [
+                InlineKeyboardButton(
+                    text="🤖 Go to private chat", url=f"https://t.me/{const.SELF_BOT_NAME}"
+                )
+            ]
         ],
-        'help': 'Tell a member to stop spamming and switch to a private chat',
+        "help": "Tell a member to stop spamming and switch to a private chat",
     },
-    '#userbot': {
-        'message': (
+    "userbot": {
+        "message": (
             '{query} Refer to <a href="https://telegra.ph/How-a-Userbot-superacharges-your-'
             'Telegram-Bot-07-09">this article</a> to learn more about <b>Userbots</b>.'
         ),
-        'help': "What are Userbots?",
-        'default': '',
+        "help": "What are Userbots?",
+        "default": "",
     },
-    '#snippets': {
-        'message': (
+    "snippets": {
+        "message": (
             '<a href="https://github.com/python-telegram-bot/python-telegram-bot/wiki/'
             'Code-snippets">Here</a> '
-            'you can find many useful code snippets for the work with python-telegram-bot'
+            "you can find many useful code snippets for the work with python-telegram-bot"
         ),
-        'help': "Link to the wiki's snippets section",
+        "help": "Link to the wiki's snippets section",
     },
-    '#pprint': {
-        'message': (
-            'The most convenient way of <b>pretty-printing an update</b> is:\n\n'
-            '<pre>from pprint import pprint\npprint(update.to_dict())</pre>\n\n'
-            'It shows you what attributes are available in an update. Alternatively, use a json '
-            'dumping bot like @JsonDumpBot or @JsonDumpBetaBot for a general overview, but keep '
-            'in mind that this method won\'t be entirely consistent with your bots updates '
-            '(different file_ids for example).'
+    "pprint": {
+        "message": (
+            "The most convenient way of <b>pretty-printing an update</b> is:\n\n"
+            "<pre>from pprint import pprint\npprint(update.to_dict())</pre>\n\n"
+            "It shows you what attributes are available in an update. Alternatively, use a json "
+            "dumping bot like @JsonDumpBot or @JsonDumpBetaBot for a general overview, but keep "
+            "in mind that this method won't be entirely consistent with your bots updates "
+            "(different file_ids for example)."
         ),
-        'help': "Explain how to pretty-print an update",
+        "help": "Explain how to pretty-print an update",
     },
-    '#meta': {
-        'message': (
+    "meta": {
+        "message": (
             'No need for meta questions. <a href="https://dontasktoask.com">Just ask</a>! 🤗'
             '<i>"Has anyone done .. before?" </i>'
-            'Probably. <b>Just ask your question and somebody will help!</b>'
+            "Probably. <b>Just ask your question and somebody will help!</b>"
         ),
-        'help': "Show our stance on meta-questions",
+        "help": "Show our stance on meta-questions",
     },
-    '#tutorial': {
-        'message': (
-            '{query}'
-            'We have compiled a list of learning resources <i>just for you</i>:\n\n'
+    "tutorial": {
+        "message": (
+            "{query}"
+            "We have compiled a list of learning resources <i>just for you</i>:\n\n"
             '• <a href="https://wiki.python.org/moin/BeginnersGuide/NonProgrammers">As Beginner'
-            '</a>\n'
+            "</a>\n"
             '• <a href="https://wiki.python.org/moin/BeginnersGuide/Programmers">As Programmer'
-            '</a>\n'
+            "</a>\n"
             '• <a href="https://docs.python.org/3/tutorial/">Official Tutorial</a>\n'
             '• <a href="http://www.diveintopython3.net/">Dive into Python</a>\n'
             '• <a href="https://www.learnpython.org/">Learn Python</a>\n'
             '• <a href="https://cscircles.cemc.uwaterloo.ca/">Computer Science Circles</a>\n'
             '• <a href="https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/'
             '6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016/">MIT '
-            'OpenCourse</a>\n'
+            "OpenCourse</a>\n"
             '• <a href="https://docs.python-guide.org/">Hitchhiker’s Guide to Python</a>\n'
-            '• The @PythonRes Telegram Channel.\n'
+            "• The @PythonRes Telegram Channel.\n"
             '• Corey Schafer videos for <a href="https://www.youtube.com/watch?v=YYXdXT2l-Gg&list'
             '=PL-osiE80TeTskrapNbzXhwoFUiLCjGgY7">beginners</a> and in <a href="https://www.'
             'youtube.com/watch?v=YYXdXT2l-Gg&list=PL-osiE80TeTt2d9bfVyTiXJA-UTHn6WwU">general'
-            '</a>\n'
+            "</a>\n"
             '• <a href="http://projectpython.net/chapter00/">Project Python</a>\n'
         ),
-        'help': "How to find a Python tutorial",
-        'default': (
+        "help": "How to find a Python tutorial",
+        "default": (
             "Oh, hey! There's someone new joining our awesome community of Python developers "
             "❤️ "
         ),
     },
-    '#wronglib': {
-        'message': (
-            '{query} If you insist on using that other one, please go where you belong: '
+    "wronglib": {
+        "message": (
+            "{query} If you insist on using that other one, please go where you belong: "
             '<a href="https://telegram.me/joinchat/Bn4ixj84FIZVkwhk2jag6A">pyTelegramBotApi</a>, '
             '<a href="https://github.com/nickoala/telepot">Telepot</a>, '
             '<a href="https://t.me/Pyrogram">pyrogram</a>, '
@@ -110,223 +103,146 @@ HINTS: Dict[str, HintDict] = {
             '<a href="https://t.me/aiogram">aiogram</a>, '
             '<a href="https://t.me/botogram_users">botogram</a>.'
         ),
-        'help': "Other Python wrappers for Telegram",
-        'default': (
+        "help": "Other Python wrappers for Telegram",
+        "default": (
             "Hey, I think you're wrong 🧐\nIt looks like you're not using the python-telegram-bot "
             "library."
         ),
     },
-    '#askright': {
-        'message': (
-            '{query} In order for someone to be able to help you, you must ask a <b>good '
+    "askright": {
+        "message": (
+            "{query} In order for someone to be able to help you, you must ask a <b>good "
             'technical question</b>. Please read <a href="https://github.com/python-telegram-bot/'
             'python-telegram-bot/wiki/Ask-Right">this short article</a> and try again ;)'
         ),
-        'help': "The wiki page about asking technical questions",
-        'default': 'Hey.',
+        "help": "The wiki page about asking technical questions",
+        "default": "Hey.",
     },
-    '#broadcast': {
-        'message': (
+    "broadcast": {
+        "message": (
             '{query} Broadcasting to users is a common use case. This <a href="https://telegra.ph/'
             'Sending-notifications-to-all-users-07-17">short article</a> summarizes the most '
-            'important tips for that.'
+            "important tips for that."
         ),
-        'help': "FAQ for broadcasting to users.",
-        'default': 'Hey.',
+        "help": "FAQ for broadcasting to users.",
+        "default": "Hey.",
     },
-    '#mwe': {
-        'message': (
+    "mwe": {
+        "message": (
             '{query} Have a look at <a href="https://telegra.ph/Minimal-Working-Example-for-PTB-'
             '07-18">this short article</a> for information on what a MWE is.'
         ),
-        'help': "How to build an MWE for PTB.",
-        'default': 'Hey. Please provide a minimal working example (MWE).',
+        "help": "How to build an MWE for PTB.",
+        "default": "Hey. Please provide a minimal working example (MWE).",
     },
-    '#pastebin': {
-        'message': (
+    "pastebin": {
+        "message": (
             "{query} Please post code using a pastebin rather then as plain text or screenshots. "
             "https://pastebin.com/ is quite popular, but there are many alternatives out there."
             " Of course, for very short snippets, text is fine. Please at least format it as "
             "monospace in that case."
         ),
-        'help': "Ask users not to post code as text or images.",
-        'default': 'Hey.',
+        "help": "Ask users not to post code as text or images.",
+        "default": "Hey.",
     },
-    '#doublepost': {
-        'message': (
+    "doublepost": {
+        "message": (
             "{query} Please don't double post. Questions usually are on-topic only in one of the "
             "two groups anyway."
         ),
-        'help': "Ask users not to post the same question in both on- and off-topic.",
-        'default': 'Hey.',
+        "help": "Ask users not to post the same question in both on- and off-topic.",
+        "default": "Hey.",
     },
-    '#formatting': {
-        'message': (
-            '{query} Telegram supports some formatting options for text. All the details about '
+    "formatting": {
+        "message": (
+            "{query} Telegram supports some formatting options for text. All the details about "
             'what is supported can be found <a href="https://core.telegram.org/bots/api#formatting'
             '-options">here</a>. You can format text with every API method/type that has a '
-            '<code>parse_mode</code> parameter. In addition to editing your text as described in '
-            'the link above, pass one of the parse modes available through '
+            "<code>parse_mode</code> parameter. In addition to editing your text as described in "
+            "the link above, pass one of the parse modes available through "
             '<a href="https://python-telegram-bot.readthedocs.io/en/stable/telegram.parsemode.html'
             '">telegram.ParseMode</a> to the <code>parse_mode</code> parameter. Since the '
-            '<code>5.0</code> update of the Bot API (version <code>13.1+</code> of our library), '
+            "<code>5.0</code> update of the Bot API (version <code>13.1+</code> of our library), "
             'you can alternatively pass a list of <a href="https://python-telegram-bot.'
             'readthedocs.io/en/stable/telegram.messageentity.html">telegram.MessageEntities</a> '
-            'to the <code>entities</code> parameter.'
+            "to the <code>entities</code> parameter."
         ),
-        'default': 'Hey.',
-        'help': "How to use text formatting.",
+        "default": "Hey.",
+        "help": "How to use text formatting.",
     },
-    '#xy': {
-        'message': (
+    "xy": {
+        "message": (
             '{query} This seems like an <a href="https://xyproblem.info">xy-problem</a> to me.'
         ),
-        'default': 'Hey. What exactly do you want this for?',
-        'help': 'Ask users for the actual use case.',
+        "default": "Hey. What exactly do you want this for?",
+        "help": "Ask users for the actual use case.",
     },
-    '#dontping': {
-        'message': (
+    "dontping": {
+        "message": (
             "{query} Please only mention or reply to users directly if you're following up on a "
             "conversation with them. Otherwise just ask your question and wait if someone has a "
             "solution for you - that's how this group works 😉 Also note that the "
             "<code>@admin</code> tag is only to be used to report spam or abuse!"
         ),
-        'default': 'Hey.',
-        'help': 'Tell users not to ping randomly ping you.',
+        "default": "Hey.",
+        "help": "Tell users not to ping randomly ping you.",
     },
-    '#read': {
-        'message': (
+    "read": {
+        "message": (
             "I just pointed you to {query} and I have the strong feeling that <i>you did not "
             "actually read it</i>. Please do so. If you don't understand everything and have "
             "follow up questions, that's fine, but you can't expect me to repeat everything "
             "<i>just for you</i> because you didn't feel like reading on your own. 😉"
         ),
-        'default': 'a resource in the wiki, the docs or the examples',
-        'help': 'Tell users to actually read the resources they were linked to',
+        "default": "a resource in the wiki, the docs or the examples",
+        "help": "Tell users to actually read the resources they were linked to",
     },
-    '#ptbcontrib': {
-        'message': (
-            '{query} <code>ptbcontrib</code> is a library that provides extensions for the '
-            '<code>python-telegram-bot</code> library that written and maintained by the '
-            'community of PTB users.'
+    "ptbcontrib": {
+        "message": (
+            "{query} <code>ptbcontrib</code> is a library that provides extensions for the "
+            "<code>python-telegram-bot</code> library that written and maintained by the "
+            "community of PTB users."
         ),
-        'default': 'Hey.',
-        'buttons': [{'text': '🔗 Take me there!', 'url': f"{PTBCONTRIB_LINK}"}],
-        'help': 'Display a short info text about ptbcontrib',
+        "default": "Hey.",
+        "buttons": [[InlineKeyboardButton(text="🔗 Take me there!", url=f"{PTBCONTRIB_LINK}")]],
+        "help": "Display a short info text about ptbcontrib",
     },
-    '#botlists': {
-        'message': (
-            '{query} This group is for technical questions that come up while you code your own '
-            'Telegram bot. If you are looking for ready-to-use bots, please have a look at '
-            'channels like @BotsArchive or @BotList. There are also a number of websites that '
-            'list existing bots.'
+    "botlists": {
+        "message": (
+            "{query} This group is for technical questions that come up while you code your own "
+            "Telegram bot. If you are looking for ready-to-use bots, please have a look at "
+            "channels like @BotsArchive or @BotList. There are also a number of websites that "
+            "list existing bots."
         ),
-        'default': 'Hey.',
-        'help': "Redirect users to lists of existing bots.",
+        "default": "Hey.",
+        "help": "Redirect users to lists of existing bots.",
+    },
+    "coc": {
+        "message": (
+            '{query} Please read our <a href="https://github.com/python-telegram-bot/'
+            'python-telegram-bot/blob/master/CODE_OF_CONDUCT.md">Code of Conduct</a> and stick to '
+            "it. Note that violation of the CoC can lead to temporary or permanent banishment from"
+            " this group."
+        ),
+        "default": "Hey",
+        "help": "Remind the users of the Code of Conduct.",
     },
 }
 
 
-def list_available_hints(update: Update, _: CallbackContext) -> None:
-    if cast(Chat, update.effective_chat).type != Chat.PRIVATE:
-        text = "Please use this command in private chat with me."
-        reply_markup: Optional[InlineKeyboardMarkup] = InlineKeyboardMarkup.from_button(
-            InlineKeyboardButton('Take me there!', url=f"https://t.me/{const.SELF_BOT_NAME}")
-        )
-    else:
-        text = "You can use the following hashtags to guide new members:\n\n"
-        text += '\n'.join(
-            '🗣 {tag} ➖ {help}'.format(tag=k, help=v['help']) for k, v in HINTS.items()
-        )
-        text += "\n\nMake sure to reply to another message, so I know who to refer to."
-        reply_markup = None
-
-    message = cast(Message, update.effective_message)
-    message.reply_text(
-        text,
-        reply_markup=reply_markup,
-    )
-    message.delete()
-
-
 # Sort the hints by hey
-HINTS = dict(sorted(HINTS.items()))
-HINTS_PATTERN = re.compile(rf'(?i){"|".join(HINTS.keys())}')
-
-Hint = namedtuple('Hint', 'help, msg, reply_markup')
-
-
-def get_hints(query: str, full_match: bool = True) -> Dict[str, Hint]:
-    results = {}
-    if full_match:
-        matches = re.findall(HINTS_PATTERN, query)
-    else:
-        matches = re.findall(r'#\w+', query)
-
-    for idx, tag in enumerate(matches):
-        if idx < len(matches) - 1:
-            _, _, temp = query.partition(tag)
-            insertion_query, _, _ = temp.partition(matches[idx + 1])
-        else:
-            _, _, insertion_query = query.partition(tag)
-
-        for key, value in sorted(HINTS.items()):
-            if key.lower().startswith(tag.lower()):
-                reply_markup = (
-                    InlineKeyboardMarkup(
-                        util.build_menu(
-                            [
-                                InlineKeyboardButton(
-                                    **{
-                                        k: v.format(query=insertion_query)
-                                        for k, v in b.items()  # type: ignore
-                                    }
-                                )
-                                for b in value['buttons']
-                            ],
-                            1,
-                        )
-                    )
-                    if 'buttons' in value
-                    else None
-                )
-
-                msg = value['message'].format(
-                    query=insertion_query if insertion_query else value.get('default', '')
-                )
-
-                results[key] = Hint(help=value.get('help', ''), msg=msg, reply_markup=reply_markup)
-
-    return results
-
-
-def hint_handler(update: Update, _: CallbackContext) -> None:
-    message = cast(Message, update.effective_message)
-    reply_to = message.reply_to_message
-
-    hints = get_hints(cast(str, message.text))
-    if not hints:
-        return
-
-    deleted = False
-    for hint in hints.values():
-        message.reply_text(
-            hint.msg,
-            reply_markup=hint.reply_markup,
-            reply_to_message_id=reply_to.message_id if reply_to else None,
-        )
-        if not deleted:
-            try:
-                deleted = True
-                message.delete()
-            except BadRequest:
-                pass
-
-
-def register(dispatcher: Dispatcher) -> None:
-    dispatcher.add_handler(
-        MessageHandler(Filters.regex(HINTS_PATTERN), hint_handler, run_async=True)
+_TAG_HINTS = dict(sorted(_TAG_HINTS.items()))
+# convert into proper objects
+TAG_HINTS: Dict[str, TagHint] = {
+    key: TagHint(
+        tag=key,
+        message=value["message"],
+        description=value["help"],
+        default_query=value.get("default"),
+        inline_keyboard=InlineKeyboardMarkup(value["buttons"]) if "buttons" in value else None,
     )
-    dispatcher.add_handler(
-        CommandHandler(['hints', 'listhints'], list_available_hints, run_async=True)
-    )
+    for key, value in _TAG_HINTS.items()
+}
+TAG_HINTS_PATTERN = re.compile(
+    rf'(?i)(({"|".join(hint.short_name for hint in TAG_HINTS.values())})[^\/]*)'
+)

--- a/components/taghints.py
+++ b/components/taghints.py
@@ -184,7 +184,7 @@ _TAG_HINTS: Dict[str, Dict[str, Any]] = {
             "it. Note that violation of the CoC can lead to temporary or permanent banishment from"
             " this group."
         ),
-        "default": "Hey",
+        "default": "Hey.",
         "help": "Remind the users of the Code of Conduct.",
     },
 }

--- a/components/util.py
+++ b/components/util.py
@@ -92,7 +92,7 @@ def rate_limit(
         # Get rate limit data
         data = cast(Dict, context.chat_data).setdefault("rate_limit", {})
 
-        # If we have not seen two non-command messages since last of type `f`
+        # If we have not seen two non-command messages since last of type `func`
         if data.get(func, RATE_LIMIT_SPACING) < RATE_LIMIT_SPACING:
             logging.debug("Ignoring due to rate limit!")
             cast(Message, update.effective_message).delete()
@@ -124,7 +124,7 @@ def build_command_list(
 
     base_commands += [("rules", "Show the rules for this group.")]
 
-    if not group_name:
+    if group_name is None:
         return base_commands + hint_commands
 
     on_off_topic = [

--- a/components/util.py
+++ b/components/util.py
@@ -1,3 +1,5 @@
+# pylint:disable=cyclic-import
+# because we import truncate_str in entrytypes.Issue.short_description
 import logging
 from functools import wraps
 from typing import (

--- a/components/util.py
+++ b/components/util.py
@@ -7,6 +7,7 @@ from typing import (
     TypeVar,
     Dict,
     cast,
+    Tuple,
 )
 
 from bs4 import BeautifulSoup
@@ -14,7 +15,8 @@ from telegram import Update, InlineKeyboardButton, Message
 from telegram.error import BadRequest
 from telegram.ext import CallbackContext
 
-from .const import RATE_LIMIT_SPACING
+from .const import RATE_LIMIT_SPACING, ONTOPIC_CHAT_ID, OFFTOPIC_CHAT_ID
+from .taghints import TAG_HINTS
 
 
 def get_reply_id(update: Update) -> Optional[int]:
@@ -29,7 +31,7 @@ def reply_or_edit(update: Update, context: CallbackContext, text: str) -> None:
         try:
             chat_data[update.edited_message.message_id].edit_text(text)
         except BadRequest as exc:
-            if 'not modified' not in str(exc):
+            if "not modified" not in str(exc):
                 raise exc
     else:
         message = cast(Message, update.message)
@@ -45,8 +47,8 @@ def reply_or_edit(update: Update, context: CallbackContext, text: str) -> None:
 
 
 def get_text_not_in_entities(html: str) -> str:
-    soup = BeautifulSoup(html, 'html.parser')
-    return ' '.join(soup.find_all(text=True, recursive=False))
+    soup = BeautifulSoup(html, "html.parser")
+    return " ".join(soup.find_all(text=True, recursive=False))
 
 
 def build_menu(
@@ -64,13 +66,13 @@ def build_menu(
 
 
 def rate_limit_tracker(_: Update, context: CallbackContext) -> None:
-    data = cast(Dict, context.chat_data).setdefault('rate_limit', {})
+    data = cast(Dict, context.chat_data).setdefault("rate_limit", {})
 
     for key in data.keys():
         data[key] += 1
 
 
-Func = TypeVar('Func', bound=Callable[[Update, CallbackContext], None])
+Func = TypeVar("Func", bound=Callable[[Update, CallbackContext], None])
 
 
 def rate_limit(
@@ -78,28 +80,63 @@ def rate_limit(
 ) -> Callable[[Update, CallbackContext], None]:
     """
     Rate limit command so that RATE_LIMIT_SPACING non-command messages are
-    required between invocations.
+    required between invocations. Private chats are not rate limited.
     """
 
     @wraps(func)
     def wrapper(update: Update, context: CallbackContext) -> None:
+        if chat := update.effective_chat:
+            if chat.type == chat.PRIVATE:
+                return func(update, context)
+
         # Get rate limit data
-        try:
-            data = cast(Dict, context.chat_data)['rate_limit']
-        except KeyError:
-            data = cast(Dict, context.chat_data)['rate_limit'] = {}
+        data = cast(Dict, context.chat_data).setdefault("rate_limit", {})
 
         # If we have not seen two non-command messages since last of type `f`
         if data.get(func, RATE_LIMIT_SPACING) < RATE_LIMIT_SPACING:
-            logging.debug('Ignoring due to rate limit!')
+            logging.debug("Ignoring due to rate limit!")
+            cast(Message, update.effective_message).delete()
             return None
 
         data[func] = 0
-
         return func(update, context)
 
     return wrapper
 
 
 def truncate_str(string: str, max_length: int) -> str:
-    return (string[:max_length] + '…') if len(string) > max_length else string
+    return (string[:max_length] + "…") if len(string) > max_length else string
+
+
+def build_command_list(
+    private: bool = False, group_name: str = None, admins: bool = False
+) -> List[Tuple[str, str]]:
+
+    base_commands = [
+        ("docs", "Send the link to the docs."),
+        ("wiki", "Send the link to the wiki."),
+        ("help", "Send the link to this bots README."),
+    ]
+    hint_commands = [(hint.tag, hint.description) for hint in TAG_HINTS.values()]
+
+    if private:
+        return base_commands + hint_commands
+
+    base_commands += [("rules", "Show the rules for this group.")]
+
+    if not group_name:
+        return base_commands + hint_commands
+
+    on_off_topic = [
+        {
+            ONTOPIC_CHAT_ID: ("off_topic", "Redirect to the off-topic group"),
+            OFFTOPIC_CHAT_ID: ("on_topic", "Redirect to the on-topic group"),
+        }[group_name],
+    ]
+
+    if not admins:
+        return base_commands + on_off_topic + hint_commands
+
+    say_potato = [("say_potato", "Send captcha to a potential userbot")]
+
+    return base_commands + on_off_topic + say_potato + hint_commands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
 [tool.black]
 line-length = 99
 target-version = ['py36']
-skip-string-normalization = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 99
-target-version = ['py36']
+target-version = ['py38']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Make sure to install those as additional_dependencies in the
 # pre-commit hooks for pylint & mypy
 beautifulsoup4
-fuzzywuzzy
+thefuzz==0.19.0
 python-Levenshtein
 python-telegram-bot==13.7
 Sphinx

--- a/rules_bot.py
+++ b/rules_bot.py
@@ -104,8 +104,8 @@ def main() -> None:
     # Note: Order matters!
 
     # Simple commands
+    # The first one also handles deep linking /start commands
     dispatcher.add_handler(CommandHandler("start", start))
-    dispatcher.add_handler(CommandHandler("rules", rules))
     dispatcher.add_handler(CommandHandler("rules", rules))
     dispatcher.add_handler(CommandHandler("docs", docs))
     dispatcher.add_handler(CommandHandler("wiki", wiki))

--- a/rules_bot.py
+++ b/rules_bot.py
@@ -147,9 +147,7 @@ def main() -> None:
     logger.info('Listening...')
 
     try:
-        github_issues.set_auth(
-            config['KEYS']['github_client_id'], config['KEYS']['github_client_secret']
-        )
+        github_issues.set_auth(None, None)
     except KeyError:
         logging.info('No github api token set. Rate-limit is 60 requests/hour without auth.')
 

--- a/rules_bot.py
+++ b/rules_bot.py
@@ -20,6 +20,7 @@ from telegram.ext import (
     Defaults,
     ChatMemberHandler,
     InlineQueryHandler,
+    CallbackQueryHandler,
 )
 
 from components import inlinequeries
@@ -36,6 +37,7 @@ from components.callbacks import (
     greet_new_chat_members,
     tag_hint,
     say_potato_command,
+    say_potato_button,
 )
 from components.errorhandler import error_handler
 from components.const import (
@@ -146,6 +148,7 @@ def main() -> None:
 
     # Captcha for userbots
     dispatcher.add_handler(CommandHandler("say_potato", say_potato_command))
+    dispatcher.add_handler(CallbackQueryHandler(say_potato_button, pattern="^POTATO"))
 
     # Error Handler
     dispatcher.add_error_handler(error_handler)

--- a/rules_bot.py
+++ b/rules_bot.py
@@ -147,7 +147,13 @@ def main() -> None:
     dispatcher.add_handler(InlineQueryHandler(inlinequeries.inline_query))
 
     # Captcha for userbots
-    dispatcher.add_handler(CommandHandler("say_potato", say_potato_command))
+    dispatcher.add_handler(
+        CommandHandler(
+            "say_potato",
+            say_potato_command,
+            filters=Filters.chat(username=[ONTOPIC_USERNAME, OFFTOPIC_USERNAME]),
+        )
+    )
     dispatcher.add_handler(CallbackQueryHandler(say_potato_button, pattern="^POTATO"))
 
     # Error Handler

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ exclude = setup.py, setup-raw.py docs/source/conf.py, telegram/vendor
 
 [pylint.message-control]
 # We're ignoring a bunch of warnings, b/c rools is no high-end product …
-disable = C0116,C0115,R0902,C0114,R0912,R0914
+disable = C0116,C0115,R0902,C0114,R0912,R0914,R0913
 
 
 [mypy]


### PR DESCRIPTION
Refactors the search almost completey by unifying everything:

* all searchable entries have a common base class
* the inline search goes through *one* `InlienQueryHandler` that passes all searches through the `Search` class
* insertion-search syntax is now unified, i.e. for insertion search for tag hints and GH threads you also need to enclose the query into `+<query>+`

Closes #75

Also:

* moves tag hints from hashtags to commands (closes #76) and adds them to the command menu - let's see how many "what does this button do?" false-positives we get :D 
* adds usersbots to the rules Closes #77
* adds a `/say_potato` command to make a users fill out a captcha to verify that they are not a userbot. If they reply falsely or not withing 60 minutes, they will get banned from both groups. The command is only available for admins. The 60 minutes can be modified by typing `/say_potato <minutes>`.

There are almost surely some bugs in here - okay, I was too lazy to build test setups for  `/say_potato <minutes>`. Will try to whatch the project closely after this goes life.