### PR TITLE
Improve inline taghints

### DIFF
--- a/components/entrytypes.py
+++ b/components/entrytypes.py
@@ -502,6 +502,8 @@ class TagHint(BaseEntry):
             query_parts = search_query.split(maxsplit=1)
             if len(query_parts) == 1 and self.short_name.startswith(query_parts[0]):
                 insertion = self._default_query
+            elif query_parts and self.tag.startswith(query_parts[0]):
+                insertion = self._default_query
             else:
                 insertion = query_parts[-1]
         return self._message.format(query=insertion)
@@ -510,8 +512,10 @@ class TagHint(BaseEntry):
         return self.html_markup(search_query=search_query)
 
     def compare_to_query(self, search_query: str) -> float:
-        first = search_query.lstrip("/").split(maxsplit=1)[0]
-        return fuzz.ratio(self.tag.lower(), first.lower())
+        parts = search_query.lstrip("/").split(maxsplit=1)
+        if parts:
+            return fuzz.ratio(self.tag.lower(), parts[0].lower())
+        return 0
 
     @property
     def inline_keyboard(self) -> Optional[InlineKeyboardMarkup]:

--- a/components/entrytypes.py
+++ b/components/entrytypes.py
@@ -503,7 +503,7 @@ class TagHint(BaseEntry):
             if len(query_parts) == 1 and self.short_name.startswith(query_parts[0]):
                 insertion = self._default_query
             elif query_parts and self.tag.startswith(query_parts[0]):
-                insertion = self._default_query
+                insertion = self._default_query if len(query_parts) == 1 else query_parts[1]
             else:
                 insertion = query_parts[-1]
         return self._message.format(query=insertion)

--- a/components/util.py
+++ b/components/util.py
@@ -71,6 +71,13 @@ def build_menu(
     return menu
 
 
+def try_to_delete(message: Message) -> bool:
+    try:
+        return message.delete()
+    except (BadRequest, Unauthorized):
+        return False
+
+
 def rate_limit_tracker(_: Update, context: CallbackContext) -> None:
     data = cast(Dict, context.chat_data).setdefault("rate_limit", {})
 
@@ -101,7 +108,7 @@ def rate_limit(
         # If we have not seen two non-command messages since last of type `func`
         if data.get(func, RATE_LIMIT_SPACING) < RATE_LIMIT_SPACING:
             logging.debug("Ignoring due to rate limit!")
-            cast(Message, update.effective_message).delete()
+            try_to_delete(cast(Message, update.effective_message))
             return None
 
         data[func] = 0
@@ -146,10 +153,3 @@ def build_command_list(
     say_potato = [("say_potato", "Send captcha to a potential userbot")]
 
     return base_commands + on_off_topic + say_potato + hint_commands
-
-
-def try_to_delete(message: Message) -> bool:
-    try:
-        return message.delete()
-    except (BadRequest, Unauthorized):
-        return False


### PR DESCRIPTION
* avoids exception when inline query is just `/`
* avoids one more exception on deleting messages in chats that rules is not admin in
* when searching `@roolsbot askright foo bar`, (no leading slash!) this now correctly results in `foo bar …`. 