### PR TITLE
fix: remove `bot.ini` from repo, make GraphQL authentication clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,12 @@ rules-bot will automatically delete the service messages announcing new members.
 ## Other
 
 rules-bot can make sandwiches. You can ask it to do so by typing `make me a sandwich`. We'll see, if it actually does 😉
+
+## Setting up the bot for development and testing
+
+Copy the [example INI file `bot_example.ini`](bot_example.ini) to `bot.ini` and fill in your credentials:
+- `bot_api`: your Bot API you [got from Botfather](https://core.telegram.org/bots/features#botfather);
+- `github_auth`: your GitHub personal access token (see [instructions](https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#authenticating-with-graphql)).
+GraphQL will need this token to be prepended with `Bearer `, but it will be done automatically if you don't.
+
+**Be sure not to check `bot.ini` into your repo**. 

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ rules-bot will automatically delete the service messages announcing new members.
 
 rules-bot can make sandwiches. You can ask it to do so by typing `make me a sandwich`. We'll see, if it actually does 😉
 
-## Setting up the bot for development and testing
+# Setting up the bot for development and testing
 
 Copy the [example INI file `bot_example.ini`](bot_example.ini) to `bot.ini` and fill in your credentials:
 - `bot_api`: your Bot API you [got from Botfather](https://core.telegram.org/bots/features#botfather);
 - `github_auth`: your GitHub personal access token (see [instructions](https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#authenticating-with-graphql)).
 GraphQL will need this token to be prepended with `Bearer `, but it will be done automatically if you don't.
 
-**Be sure not to check `bot.ini` into your repo**. 
+**Be sure not to commit `bot.ini`.** 

--- a/bot.ini
+++ b/bot.ini
@@ -1,3 +1,0 @@
-[KEYS]
-bot_api = 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
-github_auth = 123456

--- a/bot_example.ini
+++ b/bot_example.ini
@@ -1,0 +1,3 @@
+[KEYS]
+bot_api = 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
+github_auth = Bearer ghp_(and the rest of your GitHub token)

--- a/components/graphqlclient.py
+++ b/components/graphqlclient.py
@@ -12,10 +12,13 @@ from components.entrytypes import Commit, Discussion, Example, Issue, PTBContrib
 
 class GraphQLClient:
     def __init__(self, auth: str, user_agent: str = USER_AGENT) -> None:
+        # OAuth token must be prepended with "Bearer". User might forget to do this.
+        authorization = auth if auth.casefold().startswith('bearer ') else f'Bearer {auth}'
+
         self._transport = AIOHTTPTransport(
             url="https://api.github.com/graphql",
             headers={
-                "Authorization": auth,
+                "Authorization": authorization,
                 "user-agent": user_agent,
             },
         )

--- a/components/graphqlclient.py
+++ b/components/graphqlclient.py
@@ -13,7 +13,7 @@ from components.entrytypes import Commit, Discussion, Example, Issue, PTBContrib
 class GraphQLClient:
     def __init__(self, auth: str, user_agent: str = USER_AGENT) -> None:
         # OAuth token must be prepended with "Bearer". User might forget to do this.
-        authorization = auth if auth.casefold().startswith('bearer ') else f'Bearer {auth}'
+        authorization = auth if auth.casefold().startswith("bearer ") else f"Bearer {auth}"
 
         self._transport = AIOHTTPTransport(
             url="https://api.github.com/graphql",


### PR DESCRIPTION
closes #100
- remove `bot.ini` from repo. It is already in `.gitignore`
- instead, create an example INI file
- add instructions on where to copy the INI file and what to put there