### PR TITLE
Expand the acronym "MWE" in the canned template

### DIFF
--- a/components/taghints.py
+++ b/components/taghints.py
@@ -28,7 +28,7 @@ _TAG_HINTS: Dict[str, Dict[str, Any]] = {
     "mwe": {
         "message": (
             '{query} Have a look at <a href="https://github.com/python-telegram-bot/python-'
-            'telegram-bot/wiki/MWE">this short article</a> for information on what a MWE is.'
+            'telegram-bot/wiki/MWE">Minimal Working Example (MWE)</a> if you need help.'
         ),
         "help": "How to build an MWE for PTB.",
         "default": "Hey. Please provide a minimal working example (MWE).",


### PR DESCRIPTION
The words "minimal working example" is self-explanatory for those who read English. Hiding this straightforward expression behind an acronym and a link makes it less accessible. This PR expands the acronym and slightly rewords the prompt, with the hope that one who understands the words "minimal", "working" and "example" would less often find it necessary to click the link and read an extra web page, thereby improving the efficiency of communication.

Context: <https://t.me/pythontelegrambotgroup/653665>