### PR TITLE
Compat taghint by regex

### DIFF
--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -507,3 +507,33 @@ async def command_token_warning(update: Update, context: ContextTypes.DEFAULT_TY
 
     if message.reply_to_message:
         await _token_warning(message.reply_to_message, context)
+
+async def compat_warning(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """When someone posts an error message indicative of a compatibility issue:
+    Reply with the /compat taghint
+    """
+    message = cast(Message, update.effective_message)
+    reply_to = message.reply_to_message
+    first_match = cast(int, MessageLimit.MAX_TEXT_LENGTH)
+
+    # Get the compat hint
+    hint = TAG_HINTS["compat"]
+
+    # Store the message
+    messages = hint.html_markup("compat")
+    # Store the keyboard
+    buttons = [
+        [deepcopy(button) for button in row] for row in hint.inline_keyboard
+    ]
+
+    keyboard = InlineKeyboardMarkup(buttons)
+
+    effective_text = "\n➖\n".join(messages)
+    await message.reply_text(
+        effective_text,
+        reply_markup=keyboard,
+        reply_to_message_id=get_reply_id(update),
+    )
+
+    if reply_to and first_match == 0:
+        await try_to_delete(message)

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -508,6 +508,7 @@ async def command_token_warning(update: Update, context: ContextTypes.DEFAULT_TY
     if message.reply_to_message:
         await _token_warning(message.reply_to_message, context)
 
+
 async def compat_warning(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """When someone posts an error message indicative of a compatibility issue:
     Reply with the /compat taghint

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -514,25 +514,11 @@ async def compat_warning(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
     Reply with the /compat taghint
     """
     message = cast(Message, update.effective_message)
-    reply_to = message.reply_to_message
-    first_match = cast(int, MessageLimit.MAX_TEXT_LENGTH)
 
     # Get the compat hint
     hint = TAG_HINTS["compat"]
 
-    # Store the message
-    messages = hint.html_markup("compat")
-    # Store the keyboard
-    buttons = [[deepcopy(button) for button in row] for row in cast(InlineKeyboardMarkup, hint.inline_keyboard)]
-    keyboard = InlineKeyboardMarkup(buttons)
-
-    effective_text = "\n➖\n".join(messages)
     await message.reply_text(
-        effective_text,
-        reply_markup=keyboard,
-        reply_to_message_id=get_reply_id(update),
+        hint.html_markup(),
+        reply_markup=hint.inline_keyboard,
     )
-
-    if reply_to and first_match == 0:
-        await try_to_delete(message)
-

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -508,7 +508,8 @@ async def command_token_warning(update: Update, context: ContextTypes.DEFAULT_TY
     if message.reply_to_message:
         await _token_warning(message.reply_to_message, context)
 
-async def compat_warning(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+
+async def compat_warning(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
     """When someone posts an error message indicative of a compatibility issue:
     Reply with the /compat taghint
     """
@@ -522,10 +523,7 @@ async def compat_warning(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     # Store the message
     messages = hint.html_markup("compat")
     # Store the keyboard
-    buttons = [
-        [deepcopy(button) for button in row] for row in hint.inline_keyboard
-    ]
-
+    buttons = [[deepcopy(button) for button in row] for row in cast(InlineKeyboardMarkup, hint.inline_keyboard)]
     keyboard = InlineKeyboardMarkup(buttons)
 
     effective_text = "\n➖\n".join(messages)

--- a/components/const.py
+++ b/components/const.py
@@ -233,7 +233,8 @@ TOKEN_TEXT = "⚠️ You posted a token, go revoke it with @BotFather.\n\n"
 
 COMPAT_ERRORS = re.compile(
     r"""
-    (Updater\._{0,2}init_{0,2}\(\) got an )?
-    unexpected keyword argument ['"]*(use_context|token|use_controls|dispatcher)['"]*
-    """
+    (Updater\._{0,2}init_{0,2}\(\)\ got\ an\ )?
+    unexpected\ keyword\ argument\ ['"]*(use_context|token|use_controls|dispatcher)['"]*
+    """,
+    flags=re.VERBOSE,
 )

--- a/components/const.py
+++ b/components/const.py
@@ -230,3 +230,9 @@ BUY_TEXT = (
     "associated with."
 )
 TOKEN_TEXT = "⚠️ You posted a token, go revoke it with @BotFather.\n\n"
+
+COMPAT_ERRORS = re.compile(
+    r"""
+    (Updater\._{0,2}init_{0,2}\(\) got an )?unexpected keyword argument ['"]*(use_context|token|use_controls|dispatcher)['"]*
+    """
+)

--- a/components/const.py
+++ b/components/const.py
@@ -233,6 +233,7 @@ TOKEN_TEXT = "⚠️ You posted a token, go revoke it with @BotFather.\n\n"
 
 COMPAT_ERRORS = re.compile(
     r"""
-    (Updater\._{0,2}init_{0,2}\(\) got an )?unexpected keyword argument ['"]*(use_context|token|use_controls|dispatcher)['"]*
+    (Updater\._{0,2}init_{0,2}\(\) got an )?
+    unexpected keyword argument ['"]*(use_context|token|use_controls|dispatcher)['"]*
     """
 )

--- a/rules_bot.py
+++ b/rules_bot.py
@@ -28,6 +28,7 @@ from components.callbacks import (
     ban_sender_channels,
     buy,
     command_token_warning,
+    compat_warning,
     delete_message,
     leave_chat,
     off_on_topic,
@@ -40,17 +41,16 @@ from components.callbacks import (
     say_potato_command,
     start,
     tag_hint,
-    compat_warning,
 )
 from components.const import (
     ALLOWED_CHAT_IDS,
     ALLOWED_USERNAMES,
+    COMPAT_ERRORS,
     ERROR_CHANNEL_CHAT_ID,
     OFFTOPIC_CHAT_ID,
     OFFTOPIC_USERNAME,
     ONTOPIC_CHAT_ID,
     ONTOPIC_USERNAME,
-    COMPAT_ERRORS,
 )
 from components.errorhandler import error_handler
 from components.joinrequests import join_request_buttons, join_request_callback
@@ -172,11 +172,7 @@ def main() -> None:
     application.add_handler(MessageHandler(TagHintFilter(), tag_hint))
 
     # Compat tag hint via regex
-    application.add_handler(
-        MessageHandler(
-            filters.Regex(COMPAT_ERRORS), compat_warning
-        )
-    )
+    application.add_handler(MessageHandler(filters.Regex(COMPAT_ERRORS), compat_warning))
 
     # We need several matches so filters.REGEX is basically useless
     # therefore we catch everything and do regex ourselves

--- a/rules_bot.py
+++ b/rules_bot.py
@@ -40,6 +40,7 @@ from components.callbacks import (
     say_potato_command,
     start,
     tag_hint,
+    compat_warning,
 )
 from components.const import (
     ALLOWED_CHAT_IDS,
@@ -49,6 +50,7 @@ from components.const import (
     OFFTOPIC_USERNAME,
     ONTOPIC_CHAT_ID,
     ONTOPIC_USERNAME,
+    COMPAT_ERRORS,
 )
 from components.errorhandler import error_handler
 from components.joinrequests import join_request_buttons, join_request_callback
@@ -168,6 +170,13 @@ def main() -> None:
 
     # Tag hints - works with regex
     application.add_handler(MessageHandler(TagHintFilter(), tag_hint))
+
+    # Compat tag hint via regex
+    application.add_handler(
+        MessageHandler(
+            filters.Regex(COMPAT_ERRORS), compat_warning
+        )
+    )
 
     # We need several matches so filters.REGEX is basically useless
     # therefore we catch everything and do regex ourselves


### PR DESCRIPTION
Sorry, I wasn't able to run it due to pip issues with unicode, but VSC doesn't show any warnings or errors, so it at least passes the baseline test.

The `COMPAT_ERRORS` regex pattern was tested manually for most of messages occuring in 2024 based on a `got an unexpected keyword` search query in the main PTB group, and __seems__ to work as intended, including no false positives on other messages from that query that aren't related to the compat taghint.